### PR TITLE
[Fix] Add include closed filter to dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -170,6 +170,7 @@ def dashboard():
     team_filter = request.args.get("team", "my_team")
     status_filter = request.args.get("status", "open")
     search_term = request.args.get("q", "").strip()
+    include_closed = request.args.get("include_closed") == "1"
 
     # Team-ID bestimmen
     if team_filter == "my_team":
@@ -181,7 +182,10 @@ def dashboard():
 
     # Tickets laden
     tickets = get_tickets_with_filters(
-        team_id=team_id, status_filter=status_filter, search_term=search_term or None
+        team_id=team_id,
+        status_filter=status_filter,
+        search_term=search_term or None,
+        include_closed=include_closed,
     )
 
     # Teams und Status für Filter laden
@@ -196,6 +200,7 @@ def dashboard():
         current_team_filter=team_filter,
         current_status_filter=status_filter,
         search_term=search_term,
+        include_closed=include_closed,
     )
 
 

--- a/database.py
+++ b/database.py
@@ -176,7 +176,12 @@ def get_priority_by_id(priority_id):
 
 
 # TICKETS
-def get_tickets_with_filters(team_id=None, status_filter="open", search_term=None):
+def get_tickets_with_filters(
+    team_id=None,
+    status_filter="open",
+    search_term=None,
+    include_closed=False,
+):
     """Erweiterte Ticket-Abfrage mit Team-Filtern und Zuweisungen
 
     Optional kann ein Suchbegriff übergeben werden, um Tickets nach Titel oder
@@ -204,7 +209,7 @@ def get_tickets_with_filters(team_id=None, status_filter="open", search_term=Non
         conditions.append("t.TeamID = ?")
         params.append(team_id)
 
-    if status_filter == "open":
+    if status_filter == "open" and not include_closed:
         conditions.append("s.StatusName != 'Gelöst'")
     elif status_filter != "all":
         conditions.append("s.StatusName = ?")

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -48,6 +48,10 @@
                 <label>Suche:</label>
                 <input type="text" id="search-input" value="{{ search_term }}" placeholder="Titel oder ID">
                 <button onclick="applyFilters()">Suchen</button>
+                <div class="checkbox-group">
+                    <input type="checkbox" id="include-closed" {% if include_closed %}checked{% endif %}>
+                    <label for="include-closed" title="Auch gelöste Tickets anzeigen">Abgeschlossene einschließen</label>
+                </div>
             </div>
         </div>
     </div>
@@ -105,6 +109,7 @@ function applyFilters() {
     const teamFilter = document.getElementById('team-filter').value;
     const statusFilter = document.getElementById('status-filter').value;
     const searchValue = document.getElementById('search-input').value;
+    const includeClosed = document.getElementById('include-closed').checked;
 
     const url = new URL(window.location);
     url.searchParams.set('team', teamFilter);
@@ -113,6 +118,11 @@ function applyFilters() {
         url.searchParams.set('q', searchValue);
     } else {
         url.searchParams.delete('q');
+    }
+    if (includeClosed) {
+        url.searchParams.set('include_closed', '1');
+    } else {
+        url.searchParams.delete('include_closed');
     }
 
     window.location = url;


### PR DESCRIPTION
## Summary
Adds the `include_closed` option to dashboard filtering. Tickets can now be queried including solved ones through a checkbox and a new request parameter. The database query and dashboard handler were updated accordingly.

## Testing Done
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a33f7c1c48327b30ed5eac2e4d228