### PR TITLE
[Fix] allow zip attachment uploads

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,7 +11,17 @@ DATABASE = {
 
 # Upload-Konfiguration
 UPLOAD_FOLDER = os.path.join(BASE_DIR, "static", "uploads")
-ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "pdf", "doc", "docx", "txt"}
+ALLOWED_EXTENSIONS = {
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "pdf",
+    "doc",
+    "docx",
+    "txt",
+    "zip",
+}
 MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10MB
 
 # Flask-Konfiguration


### PR DESCRIPTION
## Summary
- support uploading `.zip` files by adding the extension to `ALLOWED_EXTENSIONS`

## Testing Done
- `flake8`
- `pytest tests/` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa9651bac8327b8008f0bb38aaa5c