### PR TITLE
[Fix] Add agent filter for ticket dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -166,14 +166,16 @@ def logout():
 
 @app.route("/")
 def dashboard():
-    """Dashboard mit Team-Filter"""
+    """Dashboard mit Team- und Agent-Filtern"""
     # Filter aus Query-Parametern
     team_filter = request.args.get("team", "mine")
     status_filter = request.args.get("status", "open")
     search_term = request.args.get("q", "").strip()
+    agent_filter_param = request.args.get("agent")
 
     # Team-ID bestimmen
     agent_filter = None
+    assigned_only = False
     if team_filter == "my_team":
         team_id = g.current_agent["TeamID"]
     elif team_filter == "all":
@@ -184,17 +186,23 @@ def dashboard():
     else:
         team_id = int(team_filter) if team_filter.isdigit() else None
 
+    if agent_filter_param:
+        agent_filter = int(agent_filter_param)
+        assigned_only = True
+
     # Tickets laden
     tickets = get_tickets_with_filters(
         team_id=team_id,
         status_filter=status_filter,
         search_term=search_term or None,
         agent_id=agent_filter,
+        assigned_only=assigned_only,
     )
 
     # Teams und Status für Filter laden
     teams = get_all_teams()
     statuses = get_all_statuses()
+    agents = load_agents()
 
     return render_template(
         "dashboard.html",
@@ -205,6 +213,8 @@ def dashboard():
         current_status_filter=status_filter,
         search_term=search_term,
         old_ticket_threshold=OLD_TICKET_THRESHOLD_DAYS,
+        agents=agents,
+        current_agent_filter=agent_filter_param,
     )
 
 

--- a/database.py
+++ b/database.py
@@ -177,7 +177,11 @@ def get_priority_by_id(priority_id):
 
 # TICKETS
 def get_tickets_with_filters(
-    team_id=None, status_filter="open", search_term=None, agent_id=None
+    team_id=None,
+    status_filter="open",
+    search_term=None,
+    agent_id=None,
+    assigned_only=False,
 ):
     """Erweiterte Ticket-Abfrage mit Team-Filtern und Zuweisungen
 
@@ -221,9 +225,13 @@ def get_tickets_with_filters(
         params.append(search_term if str(search_term).isdigit() else -1)
 
     if agent_id:
-        conditions.append("(ta.AgentID = ? OR t.CreatedByAgentID = ?)")
-        params.append(agent_id)
-        params.append(agent_id)
+        if assigned_only:
+            conditions.append("ta.AgentID = ?")
+            params.append(agent_id)
+        else:
+            conditions.append("(ta.AgentID = ? OR t.CreatedByAgentID = ?)")
+            params.append(agent_id)
+            params.append(agent_id)
 
     if conditions:
         base_query += " WHERE " + " AND ".join(conditions)

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -51,6 +51,16 @@
                 </select>
             </div>
 
+            <div class="filter-group">
+                <label>Agent:</label>
+                <select id="agent-filter" onchange="applyFilters()">
+                    <option value="" {% if not current_agent_filter %}selected{% endif %}>Alle</option>
+                    {% for agent in agents %}
+                    <option value="{{ agent.AgentID }}" {% if current_agent_filter == agent.AgentID|string %}selected{% endif %}>{{ agent.AgentName }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+
             <div class="filter-group search-group">
                 <label>Suche:</label>
                 <div class="search-bar">
@@ -119,11 +129,17 @@
 function applyFilters() {
     const teamFilter = document.getElementById('team-filter').value;
     const statusFilter = document.getElementById('status-filter').value;
+    const agentFilter = document.getElementById('agent-filter').value;
     const searchValue = document.getElementById('search-input').value;
 
     const url = new URL(window.location);
     url.searchParams.set('team', teamFilter);
     url.searchParams.set('status', statusFilter);
+    if (agentFilter) {
+        url.searchParams.set('agent', agentFilter);
+    } else {
+        url.searchParams.delete('agent');
+    }
     if (searchValue) {
         url.searchParams.set('q', searchValue);
     } else {


### PR DESCRIPTION
## Summary
Adds an optional agent filter to the dashboard so tickets assigned to a specific agent can be viewed. The route now accepts a new query parameter and passes a list of agents to the template. The dashboard template includes a drop-down for agent selection and the filter logic handles the new parameter.

## Testing Done
- `flake8`
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686bda3970dc8327919709bab025c711