### PR TITLE
[Fix] Show formatted timestamps

### DIFF
--- a/app.py
+++ b/app.py
@@ -452,8 +452,14 @@ def view_ticket(ticket_id):
     # Updates laden
     updates = query_db(
         """
-        SELECT UpdateID, TicketID, UpdatedByName, UpdateText, IsSolution,
-               strftime('%d.%m.%Y %H:%M', UpdatedAt) as UpdatedAt
+        SELECT
+            UpdateID,
+            TicketID,
+            UpdatedByName,
+            UpdateText,
+            IsSolution,
+            UpdatedAt,
+            strftime('%d.%m.%Y %H:%M', UpdatedAt) AS FormattedUpdatedAt
         FROM TicketUpdates
         WHERE TicketID = ?
         ORDER BY UpdatedAt ASC
@@ -464,8 +470,13 @@ def view_ticket(ticket_id):
     # Anhänge laden
     attachments = query_db(
         """
-        SELECT AttachmentID, FileName, StoragePath, FileSize,
-               strftime('%d.%m.%Y %H:%M', UploadedAt) as UploadedAt
+        SELECT
+            AttachmentID,
+            FileName,
+            StoragePath,
+            FileSize,
+            UploadedAt,
+            strftime('%d.%m.%Y %H:%M', UploadedAt) AS FormattedUploadedAt
         FROM TicketAttachments
         WHERE TicketID = ?
         ORDER BY UploadedAt ASC

--- a/templates/ticket_view.html
+++ b/templates/ticket_view.html
@@ -144,7 +144,7 @@
                         <a href="{{ url_for('serve_attachment', filename=attachment.StoragePath) }}" 
                         target="_blank" class="attachment-name">{{ attachment.FileName }}</a>
                         <div class="attachment-meta">
-                            {{ attachment.UploadedAt }} • {{ (attachment.FileSize / 1024) | round(1) }} KB
+                            {{ attachment.FormattedUploadedAt }} • {{ (attachment.FileSize / 1024) | round(1) }} KB
                         </div>
                     </div>
                 </div>
@@ -170,7 +170,7 @@
                     <div class="bubble-content">{{ update.UpdateText }}</div>
                     <div class="bubble-meta">
                         <span class="bubble-author">{{ update.UpdatedByName }}</span>
-                        <span class="bubble-time">{{ update.UpdatedAt }}</span>
+                        <span class="bubble-time">{{ update.FormattedUpdatedAt }}</span>
                         {% if update.IsSolution %}<span class="solution-badge">Lösung</span>{% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- include raw timestamps with formatted fields in view_ticket
- render formatted timestamps in ticket_view template

## Testing Done
- `black app.py`
- `flake8 app.py`
- `pytest tests/` *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c03c586b48327a5292cfaa5e9038d