### PR TITLE
Fix umlaut display in PHP templates

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -29,7 +29,7 @@ if ($action === 'login') {
             header('Location: index.php');
             exit;
         } else {
-            $flash = 'Ung\xC3\xBCltiges Token';
+            $flash = 'Ungültiges Token';
         }
     }
     include 'templates/login.php';

--- a/php/models.php
+++ b/php/models.php
@@ -28,7 +28,7 @@ function get_tickets_with_filters($team_id = null, $status_filter = 'open', $sea
     $params = [];
     if ($team_id) { $conditions[] = 't.TeamID = ?'; $params[] = $team_id; }
     if ($status_filter === 'open') {
-        $conditions[] = "s.StatusName != 'Gel\xC3\xB6st'"; // Gelöst
+        $conditions[] = "s.StatusName != 'Gelöst'"; // Gelöst
     } elseif ($status_filter !== 'all') {
         $conditions[] = 's.StatusName = ?'; $params[] = $status_filter; }
     if ($search_term) {

--- a/php/templates/dashboard.php
+++ b/php/templates/dashboard.php
@@ -1,7 +1,7 @@
 <?php $title = 'Dashboard - IFAK Ticketsystem'; include 'templates/header.php'; ?>
 <div class="dashboard">
     <div class="dashboard-header">
-        <h1>Ticket-\xC3\x9Cbersicht</h1>
+        <h1>Ticket-Übersicht</h1>
     </div>
     <div class="dashboard-table">
         <table>
@@ -10,7 +10,7 @@
                     <th>ID</th>
                     <th>Titel</th>
                     <th>Status</th>
-                    <th>Priorit\xC3\xA4t</th>
+                    <th>Priorität</th>
                     <th>Team</th>
                     <th>Erstellt am</th>
                 </tr>

--- a/php/templates/ticket_form.php
+++ b/php/templates/ticket_form.php
@@ -9,7 +9,7 @@
         <textarea name="description" id="description" required></textarea>
     </div>
     <div class="form-group">
-        <label for="priority">Priorit\xC3\xA4t:</label>
+        <label for="priority">Priorität:</label>
         <select name="priority_id" id="priority">
             <?php foreach ($priorities as $p): ?>
             <option value="<?php echo $p['PriorityID']; ?>"><?php echo htmlspecialchars($p['PriorityName']); ?></option>

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -1,6 +1,6 @@
 <?php $title = 'Ticket #' . $ticket['TicketID']; include 'templates/header.php'; ?>
 <h2>Ticket #<?php echo $ticket['TicketID']; ?> - <?php echo htmlspecialchars($ticket['Title']); ?></h2>
-<p>Status: <?php echo htmlspecialchars($ticket['StatusName']); ?> | Priorit\xC3\xA4t: <?php echo htmlspecialchars($ticket['PriorityName']); ?></p>
+<p>Status: <?php echo htmlspecialchars($ticket['StatusName']); ?> | Priorität: <?php echo htmlspecialchars($ticket['PriorityName']); ?></p>
 <p><?php echo nl2br(htmlspecialchars($ticket['Description'])); ?></p>
 <p>Kontakt: <?php echo htmlspecialchars($ticket['ContactName']); ?></p>
 <?php if ($attachments): ?>


### PR DESCRIPTION
## Summary
- use correct umlauts in PHP templates and models
- show readable login error message

## Testing
- `php -l php/index.php`
- `php -l php/models.php`
- `php -l php/templates/dashboard.php`
- `php -l php/templates/ticket_form.php`
- `php -l php/templates/ticket_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68728492269c8327a2765469590e6be9