### PR TITLE
Fix dashboard column layout

### DIFF
--- a/php/templates/dashboard.php
+++ b/php/templates/dashboard.php
@@ -8,22 +8,32 @@
             <thead>
                 <tr>
                     <th>ID</th>
-                    <th>Titel</th>
+                    <th>Team</th>
                     <th>Status</th>
                     <th>Priorität</th>
-                    <th>Team</th>
+                    <th>Titel</th>
+                    <th>Kontakt</th>
+                    <th>Zugewiesen an</th>
                     <th>Erstellt am</th>
+                    <th>Alter (Tage)</th>
+                    <th>Erstellt von</th>
+                    <th>Quelle</th>
                 </tr>
             </thead>
             <tbody>
                 <?php foreach ($tickets as $ticket): ?>
                 <tr>
                     <td><a href="index.php?action=view_ticket&id=<?php echo $ticket['TicketID']; ?>">#<?php echo $ticket['TicketID']; ?></a></td>
+                    <td><span class="team-badge" style="background-color: <?php echo htmlspecialchars($ticket['TeamColor']); ?>;"><?php echo htmlspecialchars($ticket['TeamName']); ?></span></td>
+                    <td><span class="status-badge" style="background-color: <?php echo htmlspecialchars($ticket['StatusColor']); ?>;"><?php echo htmlspecialchars($ticket['StatusName']); ?></span></td>
+                    <td><span class="priority-badge" style="background-color: <?php echo htmlspecialchars($ticket['PriorityColor']); ?>;"><?php echo htmlspecialchars($ticket['PriorityName']); ?></span></td>
                     <td><?php echo htmlspecialchars($ticket['Title']); ?></td>
-                    <td><?php echo htmlspecialchars($ticket['StatusName']); ?></td>
-                    <td><?php echo htmlspecialchars($ticket['PriorityName']); ?></td>
-                    <td><?php echo htmlspecialchars($ticket['TeamName']); ?></td>
+                    <td><?php echo htmlspecialchars($ticket['ContactName']); ?></td>
+                    <td><?php echo htmlspecialchars($ticket['AssignedAgents']); ?></td>
                     <td><?php echo $ticket['CreatedAt']; ?></td>
+                    <td><?php echo $ticket['AgeDays']; ?></td>
+                    <td><?php echo htmlspecialchars($ticket['CreatedByName']); ?></td>
+                    <td><?php echo htmlspecialchars($ticket['Source']); ?></td>
                 </tr>
                 <?php endforeach; ?>
             </tbody>


### PR DESCRIPTION
## Summary
- expand dashboard ticket table columns
- add colored badge styling for team, status, and priority

## Testing
- `php -l php/templates/dashboard.php`
- `php -l php/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6872874f16a0832793ea72c1c5731697