### PR TITLE
Improve PHP ticket view

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -74,10 +74,68 @@ if ($action === 'new_ticket') {
     exit;
 }
 
+if ($action === 'update_ticket') {
+    $ticket_id = intval($_GET['id']);
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        $ticket = get_ticket_by_id($ticket_id);
+        if ($ticket) {
+            $status_id = $_POST['status_id'] ?? '';
+            $priority_id = $_POST['priority_id'] ?? '';
+            $assign_agent = $_POST['assign_agent'] ?? '';
+            $update_text = trim($_POST['update_text'] ?? '');
+            $is_solution = isset($_POST['is_solution']) ? 1 : 0;
+
+            if ($is_solution) {
+                $solved = query_db("SELECT StatusID FROM TicketStatus WHERE StatusName = 'Gelöst'", [], true);
+                if ($solved) { $status_id = $solved['StatusID']; }
+            }
+
+            if ($status_id && $status_id != $ticket['StatusID']) {
+                update_db('Tickets', 'TicketID', $ticket_id, ['StatusID'], [$status_id]);
+            }
+
+            if ($priority_id && $priority_id != $ticket['PriorityID']) {
+                update_db('Tickets', 'TicketID', $ticket_id, ['PriorityID'], [$priority_id]);
+            }
+
+            if ($assign_agent) {
+                $existing = query_db('SELECT 1 FROM TicketAssignees WHERE TicketID = ? AND AgentID = ?', [$ticket_id, $assign_agent], true);
+                if (!$existing) {
+                    $info = query_db('SELECT AgentName FROM Agents WHERE AgentID = ?', [$assign_agent], true);
+                    if ($info) {
+                        insert_db('TicketAssignees', ['TicketID','AgentID','AgentName','AssignedAt'], [$ticket_id,$assign_agent,$info['AgentName'],get_local_timestamp()]);
+                    }
+                }
+            }
+
+            if ($update_text !== '' || $is_solution) {
+                insert_db('TicketUpdates', ['TicketID','UpdatedByName','UpdateText','IsSolution','UpdatedAt'], [$ticket_id,$agent['AgentName'],$update_text,$is_solution,get_local_timestamp()]);
+            }
+
+            if (!empty($_FILES['attachment']['name']) && allowed_file($_FILES['attachment']['name'])) {
+                $filename = basename($_FILES['attachment']['name']);
+                $save_name = time() . '_' . $filename;
+                $path = $UPLOAD_FOLDER . '/' . $save_name;
+                move_uploaded_file($_FILES['attachment']['tmp_name'], $path);
+                optimize_image($path);
+                $size = filesize($path);
+                insert_db('TicketAttachments', ['TicketID','FileName','StoragePath','FileSize','UploadedAt'], [$ticket_id,$filename,$save_name,$size,get_local_timestamp()]);
+            }
+        }
+        header('Location: index.php?action=view_ticket&id=' . $ticket_id);
+        exit;
+    }
+}
+
 if ($action === 'view_ticket') {
     $ticket_id = intval($_GET['id']);
     $ticket = get_ticket_by_id($ticket_id);
-    $attachments = query_db('SELECT FileName, StoragePath FROM TicketAttachments WHERE TicketID = ?', [$ticket_id]);
+    $attachments = get_ticket_attachments($ticket_id);
+    $updates = get_ticket_updates($ticket_id);
+    $assignees = get_ticket_assignees($ticket_id);
+    $statuses = get_all_statuses();
+    $priorities = get_all_priorities();
+    $agents = load_agents();
     include 'templates/ticket_view.php';
     exit;
 }

--- a/php/models.php
+++ b/php/models.php
@@ -58,4 +58,27 @@ function search_tickets($term, $limit = 10) {
     $query = "SELECT TicketID, Title FROM Tickets WHERE Title LIKE ? OR CAST(TicketID AS TEXT) LIKE ? ORDER BY CreatedAt DESC LIMIT ?";
     return query_db($query, ["%$term%", "%$term%", $limit]);
 }
+
+function get_status_by_id($status_id) {
+    return query_db("SELECT StatusID, StatusName, ColorCode FROM TicketStatus WHERE StatusID = ?", [$status_id], true);
+}
+
+function get_priority_by_id($priority_id) {
+    return query_db("SELECT PriorityID, PriorityName, ColorCode FROM TicketPriorities WHERE PriorityID = ?", [$priority_id], true);
+}
+
+function get_ticket_updates($ticket_id) {
+    $query = "SELECT UpdateID, TicketID, UpdatedByName, UpdateText, IsSolution, strftime('%d.%m.%Y %H:%M', UpdatedAt, 'localtime') as FormattedUpdatedAt FROM TicketUpdates WHERE TicketID = ? ORDER BY UpdatedAt ASC";
+    return query_db($query, [$ticket_id]);
+}
+
+function get_ticket_attachments($ticket_id) {
+    $query = "SELECT AttachmentID, FileName, StoragePath, FileSize, strftime('%d.%m.%Y %H:%M', UploadedAt, 'localtime') as FormattedUploadedAt FROM TicketAttachments WHERE TicketID = ? ORDER BY UploadedAt ASC";
+    return query_db($query, [$ticket_id]);
+}
+
+function get_ticket_assignees($ticket_id) {
+    $query = "SELECT AgentID, AgentName, strftime('%d.%m.%Y %H:%M', AssignedAt, 'localtime') as AssignedAt FROM TicketAssignees WHERE TicketID = ? ORDER BY AssignedAt DESC";
+    return query_db($query, [$ticket_id]);
+}
 ?>

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -1,13 +1,167 @@
 <?php $title = 'Ticket #' . $ticket['TicketID']; include 'templates/header.php'; ?>
-<h2>Ticket #<?php echo $ticket['TicketID']; ?> - <?php echo htmlspecialchars($ticket['Title']); ?></h2>
-<p>Status: <?php echo htmlspecialchars($ticket['StatusName']); ?> | Priorität: <?php echo htmlspecialchars($ticket['PriorityName']); ?></p>
-<p><?php echo nl2br(htmlspecialchars($ticket['Description'])); ?></p>
-<p>Kontakt: <?php echo htmlspecialchars($ticket['ContactName']); ?></p>
-<?php if ($attachments): ?>
-<ul>
-<?php foreach ($attachments as $a): ?>
-<li><a href="uploads/<?php echo $a['StoragePath']; ?>" target="_blank"><?php echo htmlspecialchars($a['FileName']); ?></a></li>
-<?php endforeach; ?>
-</ul>
-<?php endif; ?>
+<div class="ticket-view">
+    <div class="ticket-header">
+        <div class="ticket-header-line">
+            <div class="ticket-meta">
+                <span class="team-badge" style="background-color: <?php echo htmlspecialchars($ticket['TeamColor']); ?>"><?php echo htmlspecialchars($ticket['TeamName']); ?></span>
+                <span class="status-badge" style="background-color: <?php echo htmlspecialchars($ticket['StatusColor']); ?>"><?php echo htmlspecialchars($ticket['StatusName']); ?></span>
+                <span class="priority-badge" style="background-color: <?php echo htmlspecialchars($ticket['PriorityColor']); ?>"><?php echo htmlspecialchars($ticket['PriorityName']); ?></span>
+                <span>Erstellt am: <?php echo $ticket['CreatedAt']; ?></span>
+                <span>von <?php echo htmlspecialchars($ticket['CreatedByName']); ?></span>
+                <?php if ($ticket['Source']): ?><span>via <?php echo htmlspecialchars($ticket['Source']); ?></span><?php endif; ?>
+            </div>
+            <span class="ticket-id">Ticket-ID: <?php echo $ticket['TicketID']; ?></span>
+        </div>
+        <h1><?php echo htmlspecialchars($ticket['Title']); ?></h1>
+    </div>
+
+    <div class="ticket-content">
+        <div class="ticket-sidebar">
+            <h3>Kontakt</h3>
+            <div class="contact-info">
+                <p><strong><?php echo htmlspecialchars($ticket['ContactName']); ?></strong></p>
+                <?php if ($ticket['ContactPhone']): ?>
+                <p>Tel: <a href="tel:<?php echo htmlspecialchars($ticket['ContactPhone']); ?>"><?php echo htmlspecialchars($ticket['ContactPhone']); ?></a></p>
+                <?php endif; ?>
+                <?php if ($ticket['ContactEmail']): ?>
+                <p>E-Mail: <a href="mailto:<?php echo htmlspecialchars($ticket['ContactEmail']); ?>"><?php echo htmlspecialchars($ticket['ContactEmail']); ?></a></p>
+                <?php endif; ?>
+            </div>
+
+            <h3>Zugewiesen an</h3>
+            <div class="assignees">
+                <?php if ($assignees): ?>
+                <div>
+                    <?php foreach ($assignees as $as): ?>
+                    <p><?php echo htmlspecialchars($as['AgentName']); ?> (<?php echo $as['AssignedAt']; ?>)</p>
+                    <?php endforeach; ?>
+                </div>
+                <?php else: ?>
+                <p>Noch keinem Agenten zugewiesen</p>
+                <?php endif; ?>
+            </div>
+
+            <h3>Anhänge</h3>
+            <div class="attachments">
+                <?php if ($attachments): ?>
+                <?php foreach ($attachments as $a): ?>
+                <div class="attachment-item">
+                    <div class="attachment-preview">
+                        <?php $ext = strtolower(pathinfo($a['FileName'], PATHINFO_EXTENSION)); ?>
+                        <?php if (in_array($ext, ['jpg','jpeg','png','gif'])): ?>
+                            <img src="../static/uploads/<?php echo $a['StoragePath']; ?>" alt="<?php echo htmlspecialchars($a['FileName']); ?>">
+                        <?php elseif ($ext == 'pdf'): ?>
+                            📄
+                        <?php elseif (in_array($ext, ['doc','docx'])): ?>
+                            📝
+                        <?php else: ?>
+                            📎
+                        <?php endif; ?>
+                    </div>
+                    <div class="attachment-info">
+                        <a href="../static/uploads/<?php echo $a['StoragePath']; ?>" target="_blank" class="attachment-name"><?php echo htmlspecialchars($a['FileName']); ?></a>
+                        <div class="attachment-meta"><?php echo $a['FormattedUploadedAt']; ?> • <?php echo round($a['FileSize']/1024,1); ?> KB</div>
+                    </div>
+                </div>
+                <?php endforeach; ?>
+                <?php else: ?>
+                <p>Keine Anhänge vorhanden</p>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <div class="ticket-details">
+            <h3>Beschreibung</h3>
+            <div class="description-bubble">
+                <div class="bubble-content"><?php echo nl2br(htmlspecialchars($ticket['Description'])); ?></div>
+            </div>
+
+            <h3>Verlauf</h3>
+            <div class="updates-list">
+                <?php foreach ($updates as $u): ?>
+                <div class="update-bubble <?php if ($u['IsSolution']) echo 'solution'; ?>">
+                    <div class="bubble-content"><?php echo nl2br(htmlspecialchars($u['UpdateText'])); ?></div>
+                    <div class="bubble-meta">
+                        <span class="bubble-author"><?php echo htmlspecialchars($u['UpdatedByName']); ?></span>
+                        <span class="bubble-time"><?php echo $u['FormattedUpdatedAt']; ?></span>
+                        <?php if ($u['IsSolution']): ?><span class="solution-badge">Lösung</span><?php endif; ?>
+                    </div>
+                </div>
+                <?php endforeach; ?>
+            </div>
+
+            <?php if ($ticket['StatusName'] != 'Gelöst'): ?>
+            <div class="update-form">
+                <form method="POST" action="index.php?action=update_ticket&id=<?php echo $ticket['TicketID']; ?>" enctype="multipart/form-data">
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="status_id">Status ändern:</label>
+                            <select id="status_id" name="status_id">
+                                <option value="">-- Unverändert --</option>
+                                <?php foreach ($statuses as $s): if ($s['StatusName'] != 'Neu' && $s['StatusName'] != 'Gelöst'): ?>
+                                <option value="<?php echo $s['StatusID']; ?>" <?php if ($s['StatusID'] == $ticket['StatusID']) echo 'selected'; ?>><?php echo htmlspecialchars($s['StatusName']); ?></option>
+                                <?php endif; endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="priority_id">Priorität ändern:</label>
+                            <select id="priority_id" name="priority_id">
+                                <option value="">-- Unverändert --</option>
+                                <?php foreach ($priorities as $p): ?>
+                                <option value="<?php echo $p['PriorityID']; ?>" <?php if ($p['PriorityID'] == $ticket['PriorityID']) echo 'selected'; ?>><?php echo htmlspecialchars($p['PriorityName']); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="assign_agent">Agent zuweisen:</label>
+                        <select id="assign_agent" name="assign_agent">
+                            <option value="">-- Niemanden zuweisen --</option>
+                            <?php foreach ($agents as $ag): ?>
+                            <option value="<?php echo $ag['AgentID']; ?>"><?php echo htmlspecialchars($ag['AgentName'] . ' (' . $ag['TeamName'] . ')'); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="update_text">Kommentar:</label>
+                        <textarea id="update_text" name="update_text" rows="4"></textarea>
+                    </div>
+                    <div class="form-group checkbox-group">
+                        <input type="checkbox" id="is_solution" name="is_solution">
+                        <label for="is_solution">Als Lösung markieren (setzt Status auf \"Gelöst\")</label>
+                    </div>
+                    <div class="form-group">
+                        <label for="attachment">Anhang hinzufügen:</label>
+                        <input type="file" id="attachment" name="attachment">
+                    </div>
+                    <div class="form-actions">
+                        <button type="submit" class="submit-button">Aktualisieren</button>
+                    </div>
+                </form>
+            </div>
+            <?php else: ?>
+            <div class="ticket-solved">
+                <h3>Ticket gelöst</h3>
+                <p>Kann daher nicht mehr bearbeitet werden.</p>
+            </div>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>
+<script>
+$('#is_solution').change(function(){
+    if($(this).is(':checked')){
+        $('#status_id').val('3');
+        $('#status_id').prop('disabled', true);
+    } else {
+        $('#status_id').prop('disabled', false);
+    }
+});
+$('#status_id option').each(function(){
+    const currentStatus = <?php echo $ticket['StatusID']; ?>;
+    const optionValue = parseInt($(this).val());
+    if(optionValue === 1 && currentStatus > 1){ $(this).remove(); }
+    if(optionValue === 3){ $(this).remove(); }
+});
+</script>
 <?php include 'templates/footer.php'; ?>


### PR DESCRIPTION
## Summary
- implement retrieval helpers for ticket updates, attachments and assignees
- add `update_ticket` action to allow modifying status, priority and adding comments
- revamp PHP ticket view template with sidebar, attachments, updates and form

## Testing
- `php -l php/index.php`
- `php -l php/models.php`
- `php -l php/templates/ticket_view.php`


------
https://chatgpt.com/codex/tasks/task_e_6872957a6c64832787b6dfe1b32fc1f2