### PR TITLE
[Fix] Style Offen button

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -184,6 +184,11 @@ main {
     border-radius: 4px;
     background-color: white;
 }
+/* 'Alle offenen' Filteroption im Dashboard wie die anderen Badges einfärben */
+#status-filter option[value="open"] {
+    background-color: var(--secondary-color);
+    color: white;
+}
 .assigned-agents {
     font-size: 0.9em;
 }


### PR DESCRIPTION
## Summary
- style the "Alle offenen" filter option like other badges

## Testing Done
- `python -m py_compile app.py database.py config.py addressbook.py`
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6872a760c0608327a04af2025cf7aa98