### PR TITLE
Fix static asset paths in PHP templates

### DIFF
--- a/php/templates/footer.php
+++ b/php/templates/footer.php
@@ -4,6 +4,6 @@
 </footer>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
-<script src="/static/js/main.js"></script>
+<script src="../static/js/main.js"></script>
 </body>
 </html>

--- a/php/templates/header.php
+++ b/php/templates/header.php
@@ -7,13 +7,13 @@ if (!isset($title)) { $title = 'IFAK Ticketsystem'; }
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php echo htmlspecialchars($title); ?></title>
-    <link rel="stylesheet" href="/static/css/style.css">
+    <link rel="stylesheet" href="../static/css/style.css">
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/ui-lightness/jquery-ui.css">
 </head>
 <body>
 <header>
     <div class="logo">
-        <a href="index.php"><img src="/static/img/ifak-ticket-logo.svg" alt="IFAK Logo" width="300"></a>
+        <a href="index.php"><img src="../static/img/ifak-ticket-logo.svg" alt="IFAK Logo" width="300"></a>
     </div>
     <nav>
         <ul>

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -49,7 +49,7 @@
                     <div class="attachment-preview">
                         <?php $ext = strtolower(pathinfo($a['FileName'], PATHINFO_EXTENSION)); ?>
                         <?php if (in_array($ext, ['jpg','jpeg','png','gif'])): ?>
-                            <img src="/static/uploads/<?php echo $a['StoragePath']; ?>" alt="<?php echo htmlspecialchars($a['FileName']); ?>">
+                            <img src="../static/uploads/<?php echo $a['StoragePath']; ?>" alt="<?php echo htmlspecialchars($a['FileName']); ?>">
                         <?php elseif ($ext == 'pdf'): ?>
                             📄
                         <?php elseif (in_array($ext, ['doc','docx'])): ?>
@@ -59,7 +59,7 @@
                         <?php endif; ?>
                     </div>
                     <div class="attachment-info">
-                        <a href="/static/uploads/<?php echo $a['StoragePath']; ?>" target="_blank" class="attachment-name"><?php echo htmlspecialchars($a['FileName']); ?></a>
+                        <a href="../static/uploads/<?php echo $a['StoragePath']; ?>" target="_blank" class="attachment-name"><?php echo htmlspecialchars($a['FileName']); ?></a>
                         <div class="attachment-meta"><?php echo $a['FormattedUploadedAt']; ?> • <?php echo round($a['FileSize']/1024,1); ?> KB</div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- ensure relative `/static` paths use `../static` from the PHP templates

## Testing
- `php -l php/templates/header.php`
- `php -l php/templates/footer.php`
- `php -l php/templates/ticket_view.php`


------
https://chatgpt.com/codex/tasks/task_e_6872b50fc3648327996b9bec45740848