### PR TITLE
Fix dashboard row click

### DIFF
--- a/php/templates/dashboard.php
+++ b/php/templates/dashboard.php
@@ -22,7 +22,7 @@
             </thead>
             <tbody>
                 <?php foreach ($tickets as $ticket): ?>
-                <tr class="ticket-row" data-href="index.php?action=view_ticket&id=<?php echo $ticket['TicketID']; ?>">
+                <tr class="ticket-row" data-href="index.php?action=view_ticket&id=<?php echo $ticket['TicketID']; ?>" onclick="window.location='index.php?action=view_ticket&id=<?php echo $ticket['TicketID']; ?>'">
                     <td><?php echo $ticket['TicketID']; ?></td>
                     <td><span class="team-badge" style="background-color: <?php echo htmlspecialchars($ticket['TeamColor']); ?>;"><?php echo htmlspecialchars($ticket['TeamName']); ?></span></td>
                     <td><span class="status-badge" style="background-color: <?php echo htmlspecialchars($ticket['StatusColor']); ?>;"><?php echo htmlspecialchars($ticket['StatusName']); ?></span></td>


### PR DESCRIPTION
## Summary
- allow ticket rows in the PHP dashboard to open the ticket directly

## Testing
- `pytest -q`
- `php -l php/templates/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_6872b9699e508327b407c4f6b884efc4