### PR TITLE
Enhance PHP dashboard filters and ticket form

### DIFF
--- a/php/templates/dashboard.php
+++ b/php/templates/dashboard.php
@@ -1,7 +1,53 @@
-<?php $title = 'Dashboard - IFAK Ticketsystem'; include 'templates/header.php'; ?>
+<?php
+$title = 'Dashboard - IFAK Ticketsystem';
+include 'templates/header.php';
+if (!isset($current_team_filter)) $current_team_filter = 'mine';
+if (!isset($current_status_filter)) $current_status_filter = 'open';
+if (!isset($search_term)) $search_term = '';
+if (!isset($current_agent_filter)) $current_agent_filter = '';
+?>
 <div class="dashboard">
     <div class="dashboard-header">
         <h1>Ticket-Übersicht</h1>
+        <div class="dashboard-filters">
+            <div class="filter-group">
+                <label>Team:</label>
+                <select id="team-filter" onchange="applyFilters()">
+                    <option value="mine" <?php if ($current_team_filter == 'mine') echo 'selected'; ?>>Meine Tickets</option>
+                    <option value="my_team" <?php if ($current_team_filter == 'my_team') echo 'selected'; ?>>Mein Team (<?php echo htmlspecialchars($agent['TeamName']); ?>)</option>
+                    <option value="all" <?php if ($current_team_filter == 'all') echo 'selected'; ?>>Alle Teams</option>
+                    <?php foreach ($teams as $t): ?>
+                    <option value="<?php echo $t['TeamID']; ?>" <?php if ($current_team_filter == $t['TeamID']) echo 'selected'; ?>><?php echo htmlspecialchars($t['TeamName']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="filter-group">
+                <label>Status:</label>
+                <select id="status-filter" onchange="applyFilters()">
+                    <option value="open" <?php if ($current_status_filter == 'open') echo 'selected'; ?>>Alle offenen</option>
+                    <option value="all" <?php if ($current_status_filter == 'all') echo 'selected'; ?>>Alle</option>
+                    <?php foreach ($statuses as $s): ?>
+                    <option value="<?php echo $s['StatusName']; ?>" <?php if ($current_status_filter == $s['StatusName']) echo 'selected'; ?>><?php echo htmlspecialchars($s['StatusName']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="filter-group">
+                <label>Agent:</label>
+                <select id="agent-filter" onchange="applyFilters()">
+                    <option value="" <?php if (!$current_agent_filter) echo 'selected'; ?>>Alle</option>
+                    <?php foreach ($agents as $ag): ?>
+                    <option value="<?php echo $ag['AgentID']; ?>" <?php if ($current_agent_filter == $ag['AgentID']) echo 'selected'; ?>><?php echo htmlspecialchars($ag['AgentName']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="filter-group search-group">
+                <label>Suche:</label>
+                <div class="search-bar">
+                    <input type="text" id="search-input" value="<?php echo htmlspecialchars($search_term); ?>" placeholder="Titel oder ID">
+                    <button onclick="applyFilters()">Suchen</button>
+                </div>
+            </div>
+        </div>
     </div>
     <div class="dashboard-table">
         <table>
@@ -46,4 +92,19 @@
         </table>
     </div>
 </div>
+<script>
+function applyFilters() {
+    const team = document.getElementById('team-filter').value;
+    const status = document.getElementById('status-filter').value;
+    const agent = document.getElementById('agent-filter').value;
+    const search = document.getElementById('search-input').value;
+
+    const url = new URL(window.location);
+    url.searchParams.set('team', team);
+    url.searchParams.set('status', status);
+    if (agent) { url.searchParams.set('agent', agent); } else { url.searchParams.delete('agent'); }
+    if (search) { url.searchParams.set('q', search); } else { url.searchParams.delete('q'); }
+    window.location = url;
+}
+</script>
 <?php include 'templates/footer.php'; ?>

--- a/php/templates/header.php
+++ b/php/templates/header.php
@@ -30,6 +30,16 @@ if (!isset($title)) { $title = 'IFAK Ticketsystem'; }
             <?php endif; ?>
         </ul>
     </nav>
+    <?php if (!empty($agents_overview)): ?>
+    <div class="agent-overview">
+        <?php foreach ($agents_overview as $ov): ?>
+            <a href="index.php?agent=<?php echo $ov['AgentID']; ?>" class="agent-link">
+                <?php echo htmlspecialchars($ov['AgentName']); ?>
+                (<?php echo $ov['OpenTickets']; ?>)
+            </a>
+        <?php endforeach; ?>
+    </div>
+    <?php endif; ?>
 </header>
 <main>
 <?php if (!empty($flash)) { echo '<div class="flash-message">' . htmlspecialchars($flash) . '</div>'; }

--- a/php/templates/ticket_form.php
+++ b/php/templates/ticket_form.php
@@ -25,8 +25,37 @@
         </select>
     </div>
     <div class="form-group">
+        <label for="assigned_agent">Zuweisen an:</label>
+        <select name="assigned_agent" id="assigned_agent">
+            <option value="">-- Nicht zuweisen --</option>
+            <?php foreach ($agents as $ag): ?>
+            <option value="<?php echo $ag['AgentID']; ?>"><?php echo htmlspecialchars($ag['AgentName'] . ' (' . $ag['TeamName'] . ')'); ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+    <div class="form-group">
         <label for="contact">Kontaktname:</label>
         <input type="text" name="contact_name" id="contact">
+    </div>
+    <div class="form-group">
+        <label for="contact_phone">Telefon:</label>
+        <input type="tel" name="contact_phone" id="contact_phone">
+    </div>
+    <div class="form-group">
+        <label for="contact_email">E-Mail:</label>
+        <input type="email" name="contact_email" id="contact_email">
+    </div>
+    <input type="hidden" name="contact_employee_id" id="contact_employee_id">
+    <input type="hidden" name="facility_id" id="facility_id">
+    <input type="hidden" name="location_id" id="location_id">
+    <input type="hidden" name="department_id" id="department_id">
+    <div class="form-group">
+        <label for="source">Ticketquelle:</label>
+        <select name="source" id="source">
+            <option value="Mail">Mail</option>
+            <option value="Anruf">Anruf</option>
+            <option value="Flur">Flur</option>
+        </select>
     </div>
     <div class="form-group">
         <label for="attachment">Anhang:</label>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -80,6 +80,22 @@ nav a.button {
     gap: 1rem;
 }
 
+.agent-overview {
+    margin-top: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.agent-overview .agent-link {
+    color: white;
+    background-color: rgba(255,255,255,0.1);
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    text-decoration: none;
+    font-size: 0.8rem;
+}
+
 /* ==============================================
    BADGES
    ============================================== */


### PR DESCRIPTION
## Summary
- add agent ticket counts for header display
- implement filters and search on the dashboard
- extend new ticket form with contact and assignment fields
- show list of agents with open ticket count in header
- add minimal styling for agent overview

## Testing
- `php -l php/index.php`
- `php -l php/models.php`
- `php -l php/templates/dashboard.php`
- `php -l php/templates/header.php`
- `php -l php/templates/ticket_form.php`


------
https://chatgpt.com/codex/tasks/task_e_6872ca5997a083278cb61479eef328b1