### PR TITLE
Center agent overview in header

### DIFF
--- a/php/templates/header.php
+++ b/php/templates/header.php
@@ -15,6 +15,16 @@ if (!isset($title)) { $title = 'IFAK Ticketsystem'; }
     <div class="logo">
         <a href="index.php"><img src="../static/img/ifak-ticket-logo.svg" alt="IFAK Logo" width="300"></a>
     </div>
+    <?php if (!empty($agents_overview)): ?>
+    <div class="agent-overview">
+        <?php foreach ($agents_overview as $ov): ?>
+            <a href="index.php?agent=<?php echo $ov['AgentID']; ?>" class="agent-link">
+                <?php echo htmlspecialchars($ov['AgentName']); ?>
+                (<?php echo $ov['OpenTickets']; ?>)
+            </a>
+        <?php endforeach; ?>
+    </div>
+    <?php endif; ?>
     <nav>
         <ul>
             <li><a href="index.php">Dashboard</a></li>
@@ -30,16 +40,6 @@ if (!isset($title)) { $title = 'IFAK Ticketsystem'; }
             <?php endif; ?>
         </ul>
     </nav>
-    <?php if (!empty($agents_overview)): ?>
-    <div class="agent-overview">
-        <?php foreach ($agents_overview as $ov): ?>
-            <a href="index.php?agent=<?php echo $ov['AgentID']; ?>" class="agent-link">
-                <?php echo htmlspecialchars($ov['AgentName']); ?>
-                (<?php echo $ov['OpenTickets']; ?>)
-            </a>
-        <?php endforeach; ?>
-    </div>
-    <?php endif; ?>
 </header>
 <main>
 <?php if (!empty($flash)) { echo '<div class="flash-message">' . htmlspecialchars($flash) . '</div>'; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -81,10 +81,12 @@ nav a.button {
 }
 
 .agent-overview {
-    margin-top: 0.5rem;
+    margin-top: 0;
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+    flex: 1;
+    justify-content: center;
 }
 
 .agent-overview .agent-link {


### PR DESCRIPTION
## Summary
- swap order of navigation and agent overview in header.php
- center agent list with flex styles

## Testing
- `php -l php/templates/header.php`
- `find php -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68737a6097f08327b0f3c45975fe666d