### PR TITLE
Fix SQLite exception setup

### DIFF
--- a/php/db.php
+++ b/php/db.php
@@ -5,8 +5,8 @@ function get_db($type = 'ticket') {
     global $DATABASE;
     static $connections = [];
     if (!isset($connections[$type])) {
-        SQLite3::enableExceptions(true);
         $db = new SQLite3($DATABASE[$type . '_db']);
+        $db->enableExceptions(true);
         $db->busyTimeout(5000);
         $connections[$type] = $db;
     }


### PR DESCRIPTION
## Summary
- correct SQLite3 `enableExceptions` call

## Testing
- `php -l php/db.php`
- `php -l php/models.php`
- `php -l php/index.php`
- `php -l php/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68737ab77a848327a4841df8479f9067