### PR TITLE
Implement related tickets in PHP

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -151,6 +151,37 @@ if ($action === 'view_ticket') {
     $attachments = get_ticket_attachments($ticket_id);
     $updates = get_ticket_updates($ticket_id);
     $assignees = get_ticket_assignees($ticket_id);
+    $related_person = [];
+    $related_facility = [];
+    $related_location = [];
+    $seen_ids = [];
+
+    if ($ticket && $ticket['ContactEmployeeID']) {
+        $related_person = get_related_tickets_by_person($ticket['ContactEmployeeID'], $ticket_id);
+        foreach ($related_person as $rp) {
+            $seen_ids[$rp['TicketID']] = true;
+        }
+    }
+
+    if ($ticket && $ticket['FacilityID']) {
+        $temp = get_related_tickets_by_facility($ticket['FacilityID'], $ticket_id);
+        foreach ($temp as $row) {
+            if (!isset($seen_ids[$row['TicketID']])) {
+                $related_facility[] = $row;
+                $seen_ids[$row['TicketID']] = true;
+            }
+        }
+    }
+
+    if ($ticket && $ticket['LocationID']) {
+        $temp = get_related_tickets_by_location($ticket['LocationID'], $ticket_id, $ticket['FacilityID'] ?? null);
+        foreach ($temp as $row) {
+            if (!isset($seen_ids[$row['TicketID']])) {
+                $related_location[] = $row;
+                $seen_ids[$row['TicketID']] = true;
+            }
+        }
+    }
     $statuses = get_all_statuses();
     $priorities = get_all_priorities();
     $agents = load_agents();

--- a/php/models.php
+++ b/php/models.php
@@ -94,4 +94,47 @@ function get_ticket_assignees($ticket_id) {
     $query = "SELECT AgentID, AgentName, strftime('%d.%m.%Y %H:%M', AssignedAt, 'localtime') as AssignedAt FROM TicketAssignees WHERE TicketID = ? ORDER BY AssignedAt DESC";
     return query_db($query, [$ticket_id]);
 }
+
+// ----------------------------------------------------------------------
+// Verwandte Tickets
+// ----------------------------------------------------------------------
+
+function get_related_tickets_by_person($employee_id, $exclude_id) {
+    $query = "SELECT t.TicketID, t.Title, t.ContactName, s.StatusName, s.ColorCode, " .
+             "team.TeamName, team.TeamColor, " .
+             "strftime('%d.%m.%Y', t.CreatedAt, 'localtime') AS CreatedAt " .
+             "FROM Tickets t " .
+             "JOIN TicketStatus s ON t.StatusID = s.StatusID " .
+             "JOIN Teams team ON t.TeamID = team.TeamID " .
+             "WHERE t.ContactEmployeeID = ? AND t.TicketID != ? AND s.StatusName != 'Gelöst' " .
+             "ORDER BY t.CreatedAt DESC LIMIT 5";
+    return query_db($query, [$employee_id, $exclude_id]);
+}
+
+function get_related_tickets_by_facility($facility_id, $exclude_id) {
+    $query = "SELECT t.TicketID, t.Title, t.ContactName, s.StatusName, s.ColorCode, " .
+             "team.TeamName, team.TeamColor, " .
+             "strftime('%d.%m.%Y', t.CreatedAt, 'localtime') AS CreatedAt " .
+             "FROM Tickets t " .
+             "JOIN TicketStatus s ON t.StatusID = s.StatusID " .
+             "JOIN Teams team ON t.TeamID = team.TeamID " .
+             "WHERE t.FacilityID = ? AND t.TicketID != ? AND s.StatusName != 'Gelöst' " .
+             "ORDER BY t.CreatedAt DESC LIMIT 5";
+    return query_db($query, [$facility_id, $exclude_id]);
+}
+
+function get_related_tickets_by_location($location_id, $exclude_id, $facility_id = null) {
+    $query = "SELECT t.TicketID, t.Title, t.ContactName, s.StatusName, s.ColorCode, " .
+             "team.TeamName, team.TeamColor, " .
+             "strftime('%d.%m.%Y', t.CreatedAt, 'localtime') AS CreatedAt " .
+             "FROM Tickets t " .
+             "JOIN TicketStatus s ON t.StatusID = s.StatusID " .
+             "JOIN Teams team ON t.TeamID = team.TeamID " .
+             "WHERE t.LocationID = ? AND t.TicketID != ? " .
+             "AND (t.FacilityID != ? OR t.FacilityID IS NULL) " .
+             "AND s.StatusName != 'Gelöst' " .
+             "ORDER BY t.CreatedAt DESC LIMIT 5";
+    $fid = $facility_id ? $facility_id : 0;
+    return query_db($query, [$location_id, $exclude_id, $fid]);
+}
 ?>

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -28,6 +28,59 @@
                 <?php endif; ?>
             </div>
 
+            <?php if ($related_person): ?>
+            <h3>Weitere Tickets dieser Person</h3>
+            <div class="related-tickets">
+                <?php foreach ($related_person as $rel): ?>
+                <p>
+                    <span class="team-badge small" style="background-color: <?php echo htmlspecialchars($rel['TeamColor']); ?>">
+                        <?php echo htmlspecialchars($rel['TeamName']); ?>
+                    </span>
+                    <a href="index.php?action=view_ticket&id=<?php echo $rel['TicketID']; ?>">
+                        #<?php echo $rel['TicketID']; ?>: <?php echo htmlspecialchars(mb_strimwidth($rel['Title'],0,40,'...')); ?>
+                    </a>
+                    <small>(<?php echo $rel['CreatedAt']; ?>)</small>
+                </p>
+                <?php endforeach; ?>
+            </div>
+            <?php endif; ?>
+
+            <?php if ($related_facility): ?>
+            <h3>Weitere Tickets dieser Einrichtung</h3>
+            <div class="related-tickets">
+                <?php foreach ($related_facility as $rel): ?>
+                <p>
+                    <span class="team-badge small" style="background-color: <?php echo htmlspecialchars($rel['TeamColor']); ?>">
+                        <?php echo htmlspecialchars($rel['TeamName']); ?>
+                    </span>
+                    <a href="index.php?action=view_ticket&id=<?php echo $rel['TicketID']; ?>">
+                        #<?php echo $rel['TicketID']; ?>: <?php echo htmlspecialchars(mb_strimwidth($rel['Title'],0,40,'...')); ?>
+                    </a>
+                    <em>(<?php echo htmlspecialchars(explode(' ', trim($rel['ContactName']))[0]); ?>)</em>
+                    <small>(<?php echo $rel['CreatedAt']; ?>)</small>
+                </p>
+                <?php endforeach; ?>
+            </div>
+            <?php endif; ?>
+
+            <?php if ($related_location): ?>
+            <h3>Weitere Tickets an diesem Standort</h3>
+            <div class="related-tickets">
+                <?php foreach ($related_location as $rel): ?>
+                <p>
+                    <span class="team-badge small" style="background-color: <?php echo htmlspecialchars($rel['TeamColor']); ?>">
+                        <?php echo htmlspecialchars($rel['TeamName']); ?>
+                    </span>
+                    <a href="index.php?action=view_ticket&id=<?php echo $rel['TicketID']; ?>">
+                        #<?php echo $rel['TicketID']; ?>: <?php echo htmlspecialchars(mb_strimwidth($rel['Title'],0,30,'...')); ?>
+                    </a>
+                    <em>(<?php echo htmlspecialchars(explode(' ', trim($rel['ContactName']))[0]); ?>)</em>
+                    <small>(<?php echo $rel['CreatedAt']; ?>)</small>
+                </p>
+                <?php endforeach; ?>
+            </div>
+            <?php endif; ?>
+
             <h3>Zugewiesen an</h3>
             <div class="assignees">
                 <?php if ($assignees): ?>


### PR DESCRIPTION
## Summary
- support viewing related tickets in PHP version
- query related tickets by person, facility and location
- display the ticket lists in the sidebar of the ticket view

## Testing
- `php -l php/models.php`
- `php -l php/index.php`
- `php -l php/templates/ticket_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68737d75dba483278382d02c6be731c0