### PR TITLE
Port remaining Flask features to PHP

### DIFF
--- a/php/api/employee.php
+++ b/php/api/employee.php
@@ -1,0 +1,19 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../models.php';
+
+header('Content-Type: application/json');
+$employee_id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+if ($employee_id <= 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid ID']);
+    exit;
+}
+$employee = get_employee_details($employee_id);
+if (!$employee) {
+    http_response_code(404);
+    echo json_encode(['error' => 'Mitarbeiter nicht gefunden']);
+    exit;
+}
+echo json_encode($employee);
+

--- a/php/api/search_employees.php
+++ b/php/api/search_employees.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../models.php';
+
+header('Content-Type: application/json');
+$term = $_GET['term'] ?? '';
+if (strlen($term) < 2) {
+    echo json_encode([]);
+    exit;
+}
+$results = search_employees($term);
+echo json_encode($results);

--- a/php/api/search_tickets.php
+++ b/php/api/search_tickets.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../models.php';
+
+header('Content-Type: application/json');
+$term = $_GET['term'] ?? '';
+if (strlen($term) < 2) {
+    echo json_encode([]);
+    exit;
+}
+$results = search_tickets($term);
+echo json_encode($results);

--- a/php/index.php
+++ b/php/index.php
@@ -182,6 +182,15 @@ if ($action === 'view_ticket') {
             }
         }
     }
+
+    $facility_info = null;
+    $location_info = null;
+    if ($ticket && $ticket['FacilityID']) {
+        $facility_info = get_facility_info($ticket['FacilityID']);
+    }
+    if ($ticket && $ticket['LocationID']) {
+        $location_info = get_location_info($ticket['LocationID']);
+    }
     $statuses = get_all_statuses();
     $priorities = get_all_priorities();
     $agents = load_agents();

--- a/php/templates/dashboard.php
+++ b/php/templates/dashboard.php
@@ -68,7 +68,7 @@ if (!isset($current_agent_filter)) $current_agent_filter = '';
             </thead>
             <tbody>
                 <?php foreach ($tickets as $ticket): ?>
-                <tr class="ticket-row" data-href="index.php?action=view_ticket&id=<?php echo $ticket['TicketID']; ?>" onclick="window.location='index.php?action=view_ticket&id=<?php echo $ticket['TicketID']; ?>'">
+                <tr class="ticket-row<?php if ($ticket['AgeDays'] > $OLD_TICKET_THRESHOLD_DAYS && $ticket['StatusName'] != 'Gelöst') echo ' old-ticket'; ?>" data-href="index.php?action=view_ticket&id=<?php echo $ticket['TicketID']; ?>" onclick="window.location='index.php?action=view_ticket&id=<?php echo $ticket['TicketID']; ?>'">
                     <td><?php echo $ticket['TicketID']; ?></td>
                     <td><span class="team-badge" style="background-color: <?php echo htmlspecialchars($ticket['TeamColor']); ?>;"><?php echo htmlspecialchars($ticket['TeamName']); ?></span></td>
                     <td><span class="status-badge" style="background-color: <?php echo htmlspecialchars($ticket['StatusColor']); ?>;"><?php echo htmlspecialchars($ticket['StatusName']); ?></span></td>

--- a/php/templates/footer.php
+++ b/php/templates/footer.php
@@ -5,5 +5,6 @@
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
 <script src="../static/js/main.js"></script>
+<script src="../static/js/autocomplete.js"></script>
 </body>
 </html>

--- a/php/templates/ticket_form.php
+++ b/php/templates/ticket_form.php
@@ -33,9 +33,24 @@
             <?php endforeach; ?>
         </select>
     </div>
+    <h3>Kontakt</h3>
     <div class="form-group">
-        <label for="contact">Kontaktname:</label>
-        <input type="text" name="contact_name" id="contact">
+        <label for="contact_search">Kontakt suchen:</label>
+        <input type="text" id="contact_search" placeholder="Name des Mitarbeiters eingeben...">
+        <small>Mindestens 2 Zeichen eingeben für Suche im Adressbuch</small>
+    </div>
+    <div id="contact_details" class="contact-details" style="display:none;">
+        <h4>Ausgewählter Kontakt:</h4>
+        <div id="selected_contact_info"></div>
+    </div>
+
+    <div class="form-group">
+        <label for="contact_name">Name:</label>
+        <input type="text" name="contact_name" id="contact_name">
+        <input type="hidden" name="contact_employee_id" id="contact_employee_id">
+        <input type="hidden" name="facility_id" id="facility_id">
+        <input type="hidden" name="location_id" id="location_id">
+        <input type="hidden" name="department_id" id="department_id">
     </div>
     <div class="form-group">
         <label for="contact_phone">Telefon:</label>
@@ -45,10 +60,6 @@
         <label for="contact_email">E-Mail:</label>
         <input type="email" name="contact_email" id="contact_email">
     </div>
-    <input type="hidden" name="contact_employee_id" id="contact_employee_id">
-    <input type="hidden" name="facility_id" id="facility_id">
-    <input type="hidden" name="location_id" id="location_id">
-    <input type="hidden" name="department_id" id="department_id">
     <div class="form-group">
         <label for="source">Ticketquelle:</label>
         <select name="source" id="source">

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -28,6 +28,19 @@
                 <?php endif; ?>
             </div>
 
+            <?php if ($facility_info || $location_info): ?>
+            <h3>Organisation</h3>
+            <div class="organization-info">
+                <?php if ($facility_info): ?>
+                <p><strong>Einrichtung:</strong><br><?php echo htmlspecialchars($facility_info['Facility']); ?></p>
+                <?php endif; ?>
+                <?php if ($location_info): ?>
+                <p><strong>Standort:</strong><br><?php echo htmlspecialchars($location_info['Location']); ?></p>
+                <p><?php echo htmlspecialchars($location_info['Street']); ?>, <?php echo htmlspecialchars($location_info['ZIP']); ?> <?php echo htmlspecialchars($location_info['Town']); ?></p>
+                <?php endif; ?>
+            </div>
+            <?php endif; ?>
+
             <?php if ($related_person): ?>
             <h3>Weitere Tickets dieser Person</h3>
             <div class="related-tickets">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -256,6 +256,20 @@ th, td {
     background-color: #fff3cd;
 }
 
+.contact-details {
+    background-color: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 4px;
+    padding: 1rem;
+    margin-top: 1rem;
+}
+
+.organization-info {
+    color: #007bff;
+    font-size: 0.85em;
+    margin-top: 2px;
+}
+
 .no-tickets {
     text-align: center;
     padding: 2rem;

--- a/static/js/autocomplete.js
+++ b/static/js/autocomplete.js
@@ -35,27 +35,36 @@ document.addEventListener('DOMContentLoaded', function() {
         
         // Bei Auswahl eines Kontakts
         select: function(event, ui) {
-            // Ausgewählten Kontakt in die Felder einfügen
             $('#contact_name').val(ui.item.name);
             $('#contact_phone').val(ui.item.phone);
             $('#contact_email').val(ui.item.email);
-            
-            // Kontaktdetails anzeigen
+            $('#contact_employee_id').val(ui.item.id || '');
+            $('#facility_id').val(ui.item.facility_id || '');
+            $('#location_id').val(ui.item.location_id || '');
+            $('#department_id').val(ui.item.department_id || '');
+
+            const contactInfo = `
+                <p><strong>${ui.item.name}</strong></p>
+                ${ui.item.phone ? `<p>Tel: ${ui.item.phone}</p>` : ''}
+                ${ui.item.email ? `<p>E-Mail: ${ui.item.email}</p>` : ''}
+                ${ui.item.organization_info ? `<p class="organization-info">${ui.item.organization_info}</p>` : ''}
+            `;
+            $('#selected_contact_info').html(contactInfo);
             $('#contact_details').show();
-            
-            // Autocomplete-Input leeren aber Suche beenden
+
             $(this).val('');
             return false;
         }
     })
-    
+
     // Anpassung der Darstellung der Suchergebnisse
     .autocomplete("instance")._renderItem = function(ul, item) {
         return $("<li>")
-            .append("<div class='autocomplete-item'>" + 
-                    "<div class='autocomplete-name'>" + item.name + "</div>" +
-                    (item.email ? "<div class='autocomplete-email'>" + item.email + "</div>" : "") +
-                    "</div>")
+            .append(`<div class="autocomplete-item">
+                        <div class="autocomplete-name">${item.name}</div>
+                        ${item.email ? `<div class="autocomplete-email">${item.email}</div>` : ''}
+                        ${item.organization_info ? `<div class="organization-info">${item.organization_info}</div>` : ''}
+                     </div>`)
             .appendTo(ul);
     };
     


### PR DESCRIPTION
## Summary
- add address book helper functions in PHP models
- implement API endpoints for employee & ticket search
- integrate contact search in ticket creation form
- display facility/location info in ticket view
- highlight old open tickets on dashboard
- update autocomplete script and styling

## Testing
- `php -l php/api/search_employees.php`
- `php -l php/api/employee.php`
- `php -l php/api/search_tickets.php`
- `php -l php/index.php`
- `php -l php/templates/ticket_form.php`
- `php -l php/templates/ticket_view.php`
- `php -l php/templates/dashboard.php`
- `php -l php/models.php`


------
https://chatgpt.com/codex/tasks/task_e_68738edb7aac8327a4981f9cf63a947a