### PR TITLE
Add lightbox hint and overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,8 @@ Schwenk zu einer php-Version
 ## Inhalt
 Inhalt folgt.
 
+## Bildvorschau
+Vorschaubilder von Anhängen lassen sich anklicken. Ein Klick öffnet die Datei in einer Lightbox und zeigt das Bild vergrößert an.
+
 ## Kontakt
 IFAK e.V. - IT-Abteilung

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -608,6 +608,7 @@ button:hover {
     height: 40px;
     border-radius: 4px;
     object-fit: cover;
+    position: relative;
     background-color: #6c757d;
     display: flex;
     align-items: center;
@@ -615,6 +616,24 @@ button:hover {
     color: white;
     font-size: 0.8rem;
     font-weight: bold;
+}
+
+.attachment-preview::after {
+    content: '\1F50D'; /* magnifying glass */
+    position: absolute;
+    bottom: 2px;
+    right: 2px;
+    background: rgba(0,0,0,0.6);
+    color: white;
+    border-radius: 2px;
+    padding: 1px;
+    font-size: 0.7rem;
+    display: none;
+    pointer-events: none;
+}
+
+.attachment-preview:hover::after {
+    display: block;
 }
 
 .attachment-preview img {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -86,6 +86,11 @@ document.addEventListener('DOMContentLoaded', function() {
     lightbox.appendChild(img);
     document.body.appendChild(lightbox);
 
+    // Tooltip für Bildanhänge
+    document.querySelectorAll('.attachment-preview img').forEach(function(imgEl) {
+        imgEl.setAttribute('title', 'Klick zum Vergrößern');
+    });
+
     document.addEventListener('click', function(e) {
         if (e.target.matches('.attachment-preview img')) {
             e.preventDefault();


### PR DESCRIPTION
## Summary
- document lightbox feature in README
- show magnifying glass overlay on attachment previews
- add tooltip for image previews

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873bca32ee4832788129e08ec3b181b