### PR TITLE
Fix dashboard search and lightbox

### DIFF
--- a/php/models.php
+++ b/php/models.php
@@ -45,9 +45,10 @@ function get_tickets_with_filters($team_id = null, $status_filter = 'open', $sea
     } elseif ($status_filter !== 'all') {
         $conditions[] = 's.StatusName = ?'; $params[] = $status_filter; }
     if ($search_term) {
-        $conditions[] = '(t.Title LIKE ? OR t.TicketID = ?)';
+        $conditions[] = '(t.Title LIKE ? OR t.TicketID = ? OR t.ContactName LIKE ?)';
         $params[] = "%$search_term%";
         $params[] = ctype_digit($search_term) ? $search_term : -1;
+        $params[] = "%$search_term%";
     }
     if ($agent_id) {
         if ($assigned_only) {
@@ -68,8 +69,8 @@ function get_ticket_by_id($ticket_id) {
 }
 
 function search_tickets($term, $limit = 10) {
-    $query = "SELECT TicketID, Title FROM Tickets WHERE Title LIKE ? OR CAST(TicketID AS TEXT) LIKE ? ORDER BY CreatedAt DESC LIMIT ?";
-    return query_db($query, ["%$term%", "%$term%", $limit]);
+    $query = "SELECT TicketID, Title FROM Tickets WHERE Title LIKE ? OR CAST(TicketID AS TEXT) LIKE ? OR ContactName LIKE ? ORDER BY CreatedAt DESC LIMIT ?";
+    return query_db($query, ["%$term%", "%$term%", "%$term%", $limit]);
 }
 
 // ----------------------------------------------------------------------

--- a/php/templates/dashboard.php
+++ b/php/templates/dashboard.php
@@ -8,7 +8,13 @@ if (!isset($current_agent_filter)) $current_agent_filter = '';
 ?>
 <div class="dashboard">
     <div class="dashboard-header">
-        <h1>Ticket-Übersicht</h1>
+        <h1>
+            <?php if (!empty($search_term)): ?>
+                Tickets mit Suchbegriff "<?php echo htmlspecialchars($search_term); ?>"
+            <?php else: ?>
+                Ticket-Übersicht
+            <?php endif; ?>
+        </h1>
         <div class="dashboard-filters">
             <div class="filter-group">
                 <label>Team:</label>
@@ -106,5 +112,11 @@ function applyFilters() {
     if (search) { url.searchParams.set('q', search); } else { url.searchParams.delete('q'); }
     window.location = url;
 }
+document.getElementById('search-input').addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') {
+        e.preventDefault();
+        applyFilters();
+    }
+});
 </script>
 <?php include 'templates/footer.php'; ?>

--- a/php/templates/footer.php
+++ b/php/templates/footer.php
@@ -2,7 +2,7 @@
 <footer>
     <p>&copy; <?php echo date('Y'); ?> - IFAK e.V. Ticketsystem | Adressbuch-Stand: <?php echo htmlspecialchars(get_addressbook_date()); ?></p>
 </footer>
-<script src="../static/js/main.js"></script>
-<script src="../static/js/autocomplete.js"></script>
+<script src="/static/js/main.js"></script>
+<script src="/static/js/autocomplete.js"></script>
 </body>
 </html>

--- a/php/templates/header.php
+++ b/php/templates/header.php
@@ -7,12 +7,12 @@ if (!isset($title)) { $title = 'IFAK Ticketsystem'; }
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php echo htmlspecialchars($title); ?></title>
-    <link rel="stylesheet" href="../static/css/style.css">
+    <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
 <header>
     <div class="logo">
-        <a href="index.php"><img src="../static/img/ifak-ticket-logo.svg" alt="IFAK Logo" width="300"></a>
+        <a href="index.php"><img src="/static/img/ifak-ticket-logo.svg" alt="IFAK Logo" width="300"></a>
     </div>
     <?php if (!empty($agents_overview)): ?>
     <div class="agent-overview">

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -115,7 +115,7 @@
                     <div class="attachment-preview">
                         <?php $ext = strtolower(pathinfo($a['FileName'], PATHINFO_EXTENSION)); ?>
                         <?php if (in_array($ext, ['jpg','jpeg','png','gif'])): ?>
-                            <img src="../static/uploads/<?php echo $a['StoragePath']; ?>" alt="<?php echo htmlspecialchars($a['FileName']); ?>">
+                            <img src="/static/uploads/<?php echo $a['StoragePath']; ?>" alt="<?php echo htmlspecialchars($a['FileName']); ?>">
                         <?php elseif ($ext == 'pdf'): ?>
                             📄
                         <?php elseif (in_array($ext, ['doc','docx'])): ?>
@@ -125,7 +125,7 @@
                         <?php endif; ?>
                     </div>
                     <div class="attachment-info">
-                        <a href="../static/uploads/<?php echo $a['StoragePath']; ?>" target="_blank" class="attachment-name"><?php echo htmlspecialchars($a['FileName']); ?></a>
+                        <a href="/static/uploads/<?php echo $a['StoragePath']; ?>" target="_blank" class="attachment-name"><?php echo htmlspecialchars($a['FileName']); ?></a>
                         <div class="attachment-meta"><?php echo $a['FormattedUploadedAt']; ?> • <?php echo round($a['FileSize']/1024,1); ?> KB</div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- fix static asset paths for consistent lightbox use
- search tickets by contact name as well
- show search result heading
- allow search with Enter key

## Testing
- `php -l php/models.php`
- `php -l php/templates/dashboard.php`
- `php -l php/templates/header.php`
- `php -l php/templates/footer.php`
- `php -l php/templates/ticket_view.php`


------
https://chatgpt.com/codex/tasks/task_e_6873bf4353588327942ee4cfb762becd