### PR TITLE
Show ticket age in hours if below one day

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -227,17 +227,16 @@ $tickets = get_tickets_with_filters($team_id, $status_filter, $search_value ?: n
 
 // mark unassigned tickets that exceed configured thresholds based on priority
 foreach ($tickets as &$t) {
+    $created = new DateTime($t['CreatedAtTS']);
+    $now = new DateTime('now', new DateTimeZone('Europe/Berlin'));
+    $hours_total = ($now->getTimestamp() - $created->getTimestamp()) / 3600;
+    $t['AgeHours'] = (int) floor($hours_total);
     $t['Delayed'] = false;
     if (empty($t['AssignedAgents'])) {
         $prio = $t['PriorityID'];
         $threshold = $UNASSIGNED_WARNING_HOURS[$prio] ?? null;
-        if ($threshold !== null) {
-            $created = new DateTime($t['CreatedAtTS']);
-            $now = new DateTime('now', new DateTimeZone('Europe/Berlin'));
-            $hours = ($now->getTimestamp() - $created->getTimestamp()) / 3600;
-            if ($hours > $threshold) {
-                $t['Delayed'] = true;
-            }
+        if ($threshold !== null && $t['AgeHours'] > $threshold) {
+            $t['Delayed'] = true;
         }
     }
 }

--- a/php/templates/dashboard.php
+++ b/php/templates/dashboard.php
@@ -85,7 +85,7 @@ if (!isset($current_agent_filter)) $current_agent_filter = '';
                         <?php if (!empty($ticket['AssignedAgents'])): ?>
                             <?php echo htmlspecialchars($ticket['AssignedAgents']); ?>
                         <?php else: ?>
-                            <span class="unassigned-badge<?php if (!empty($ticket['Delayed'])) echo ' overdue'; ?>">Offen: <?php echo $ticket['AgeDays']; ?>d</span>
+                            <span class="unassigned-badge<?php if (!empty($ticket['Delayed'])) echo ' overdue'; ?>">Offen: <?php echo $ticket['AgeDays'] > 0 ? $ticket['AgeDays'] . 'd' : $ticket['AgeHours'] . 'h'; ?></span>
                         <?php endif; ?>
                     </td>
                     <td><?php echo $ticket['CreatedAt']; ?></td>


### PR DESCRIPTION
## Summary
- compute `AgeHours` in `index.php`
- show hours instead of days for very new tickets on dashboard

## Testing
- `php -l php/index.php`
- `php -l php/templates/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_687403193dac8327b860015db5606150