### PR TITLE
Implement automatic comment on agent assignment

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -68,6 +68,9 @@ if ($action === 'new_ticket') {
             $info = query_db('SELECT AgentName FROM Agents WHERE AgentID = ?', [$assigned_agent], true);
             if ($info) {
                 insert_db('TicketAssignees', ['TicketID','AgentID','AgentName','AssignedAt'], [$ticket_id,$assigned_agent,$info['AgentName'],get_local_timestamp()]);
+                $assign_time = (new DateTime('now', new DateTimeZone('Europe/Berlin')))->format('d.m.Y H:i');
+                $assign_note = $agent['AgentName'] . ' hat am ' . $assign_time . ' ' . $info['AgentName'] . ' zugewiesen.';
+                insert_db('TicketUpdates', ['TicketID','UpdatedByName','UpdateText','IsSolution','UpdatedAt'], [$ticket_id,$agent['AgentName'],$assign_note,0,get_local_timestamp()]);
             }
         }
         if (!empty($_FILES['attachment']['name']) && allowed_file($_FILES['attachment']['name'])) {
@@ -122,6 +125,13 @@ if ($action === 'update_ticket') {
                     $info = query_db('SELECT AgentName FROM Agents WHERE AgentID = ?', [$assign_agent], true);
                     if ($info) {
                         insert_db('TicketAssignees', ['TicketID','AgentID','AgentName','AssignedAt'], [$ticket_id,$assign_agent,$info['AgentName'],get_local_timestamp()]);
+                        $assign_time = (new DateTime('now', new DateTimeZone('Europe/Berlin')))->format('d.m.Y H:i');
+                        $assign_note = $agent['AgentName'] . ' hat am ' . $assign_time . ' ' . $info['AgentName'] . ' zugewiesen.';
+                        if ($update_text === '') {
+                            $update_text = $assign_note;
+                        } else {
+                            $update_text .= "\n\n" . $assign_note;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- append an assignment note when assigning an agent
- record the note for both ticket creation and updates

## Testing
- `php -l php/index.php`
- `find php -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68831bcfebf483279c9524a543375497