### PR TITLE
Show assigned tickets in 'Mine' filter

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -224,6 +224,7 @@ if ($team_filter === 'my_team') {
     $team_id = null;
 } elseif ($team_filter === 'mine') {
     $filter_agent = $agent['AgentID'];
+    $assigned_only = true;
 } elseif (ctype_digit($team_filter)) {
     $team_id = intval($team_filter);
 }


### PR DESCRIPTION
## Summary
- filter dashboard to show only assigned tickets when selecting **Meine Tickets**

## Testing
- `php -l php/index.php`
- `find php -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68837204c96c8327bae0cbfb8be6315e