### PR TITLE
Implement availability calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Funktionsfähige Beta
 ## Inhalt
 Inhalt folgt.
 
+## Verfügbarkeitskalender
+Jeder Agent kann seine tägliche Verfügbarkeit für drei Monate im Voraus hinterlegen. Die
+Kalenderansicht findet sich unter "Verfügbarkeiten". Im Dashboard zeigt eine Reihe farbiger
+Kästchen die Zustände der aktuellen und der kommenden Woche an.
+
 ## Bildvorschau
 Vorschaubilder von Anhängen lassen sich anklicken. Ein Klick öffnet die Datei in einer Lightbox und zeigt das Bild vergrößert an.
 

--- a/ignore/schema.sql
+++ b/ignore/schema.sql
@@ -93,6 +93,24 @@ CREATE TABLE IF NOT EXISTS "TicketAssignees" (
     FOREIGN KEY("AgentID") REFERENCES "Agents"("AgentID")
 );
 
+-- Verfügbarkeits-Status
+CREATE TABLE IF NOT EXISTS "AvailabilityStatuses" (
+    "StatusID" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "ShortCode" TEXT NOT NULL UNIQUE,
+    "StatusName" TEXT NOT NULL,
+    "ColorCode" TEXT NOT NULL
+);
+
+-- Verfügbarkeit je Agent und Tag
+CREATE TABLE IF NOT EXISTS "AgentAvailability" (
+    "AgentID" INTEGER NOT NULL,
+    "Date" DATE NOT NULL,
+    "StatusID" INTEGER NOT NULL,
+    PRIMARY KEY("AgentID","Date"),
+    FOREIGN KEY("AgentID") REFERENCES "Agents"("AgentID"),
+    FOREIGN KEY("StatusID") REFERENCES "AvailabilityStatuses"("StatusID")
+);
+
 -- Initial-Daten
 INSERT OR IGNORE INTO "Teams" VALUES (1, 'IT', '#007bff', 'IT-Support und Systemadministration');
 INSERT OR IGNORE INTO "Teams" VALUES (2, 'Haustechnik', '#28a745', 'Gebäudetechnik und Instandhaltung');
@@ -114,10 +132,18 @@ INSERT OR IGNORE INTO "Agents" VALUES (3, 'Martin', 'drees@ifak-sozial.de', '7b4
 INSERT OR IGNORE INTO "Agents" VALUES (4, 'Hussam', 'albenni@ifak-sozial.de', '2q5v8t3f7g9s', 1, 1);
 INSERT OR IGNORE INTO "Agents" VALUES (5, 'Ziad', 'errachidi@ifak-sozial.de', '4h7p2w9j5x8r', 1, 1);
 
+INSERT OR IGNORE INTO "AvailabilityStatuses" VALUES (1, 'A', 'Verfügbar', '#28a745');
+INSERT OR IGNORE INTO "AvailabilityStatuses" VALUES (2, 'U', 'Urlaub', '#dc3545');
+INSERT OR IGNORE INTO "AvailabilityStatuses" VALUES (3, 'K', 'Krank', '#800080');
+INSERT OR IGNORE INTO "AvailabilityStatuses" VALUES (4, 'S', 'Schule', '#ffc107');
+INSERT OR IGNORE INTO "AvailabilityStatuses" VALUES (5, 'F', 'Fehlt', '#ff8800');
+
 -- Performance-Indizes
 CREATE INDEX IF NOT EXISTS "idx_tickets_team" ON "Tickets"("TeamID");
 CREATE INDEX IF NOT EXISTS "idx_tickets_facility" ON "Tickets"("FacilityID");
 CREATE INDEX IF NOT EXISTS "idx_tickets_location" ON "Tickets"("LocationID");
 CREATE INDEX IF NOT EXISTS "idx_tickets_status" ON "Tickets"("StatusID");
+CREATE INDEX IF NOT EXISTS "idx_availability_agent" ON "AgentAvailability"("AgentID");
+CREATE INDEX IF NOT EXISTS "idx_availability_date" ON "AgentAvailability"("Date");
 
 COMMIT;

--- a/php/index.php
+++ b/php/index.php
@@ -20,6 +20,19 @@ if ($action !== 'login') {
         exit;
     }
     $agents_overview = get_agents_with_ticket_counts();
+    $status_map = get_availability_status_map();
+    $week1_dates = [];
+    $tmp = new DateTime('monday this week', new DateTimeZone('Europe/Berlin'));
+    for ($i=0; $i<5; $i++) { $week1_dates[] = $tmp->format('Y-m-d'); $tmp->modify('+1 day'); }
+    $week2_dates = [];
+    $tmp = new DateTime('monday next week', new DateTimeZone('Europe/Berlin'));
+    for ($i=0; $i<5; $i++) { $week2_dates[] = $tmp->format('Y-m-d'); $tmp->modify('+1 day'); }
+    $availability_overview = [];
+    foreach ($agents_overview as $ov) {
+        $a1 = get_availability_for_agent($ov['AgentID'], $week1_dates[0], $week1_dates[4]);
+        $a2 = get_availability_for_agent($ov['AgentID'], $week2_dates[0], $week2_dates[4]);
+        $availability_overview[$ov['AgentID']] = ['week1'=>$a1,'week2'=>$a2];
+    }
 }
 
 if ($action === 'login') {
@@ -41,6 +54,36 @@ if ($action === 'login') {
 if ($action === 'logout') {
     setcookie('agent_token', '', time()-3600, '/');
     header('Location: index.php?action=login');
+    exit;
+}
+
+if ($action === 'availabilities') {
+    $calendar_start = new DateTime('first day of this month', new DateTimeZone('Europe/Berlin'));
+    $calendar_end = (clone $calendar_start)->modify('+2 month')->modify('last day of this month');
+    $agents = load_agents();
+    $status_map = get_availability_status_map();
+    $avail_data = [];
+    foreach ($agents as $ag) {
+        $avail_data[$ag['AgentID']] = get_availability_for_agent($ag['AgentID'], $calendar_start->format('Y-m-d'), $calendar_end->format('Y-m-d'));
+    }
+    include 'templates/availability_overview.php';
+    exit;
+}
+
+if ($action === 'edit_availability') {
+    $calendar_start = new DateTime('first day of this month', new DateTimeZone('Europe/Berlin'));
+    $calendar_end = (clone $calendar_start)->modify('+2 month')->modify('last day of this month');
+    $statuses = get_availability_statuses();
+    $status_map = get_availability_status_map();
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        $data = $_POST['status'] ?? [];
+        foreach ($data as $date => $status_id) {
+            upsert_agent_availability($agent['AgentID'], $date, intval($status_id));
+        }
+        $flash = 'Gespeichert';
+    }
+    $availability = get_availability_for_agent($agent['AgentID'], $calendar_start->format('Y-m-d'), $calendar_end->format('Y-m-d'));
+    include 'templates/availability_edit.php';
     exit;
 }
 

--- a/php/models.php
+++ b/php/models.php
@@ -219,4 +219,39 @@ function get_related_tickets_by_location($location_id, $exclude_id, $facility_id
     $fid = $facility_id ? $facility_id : 0;
     return query_db($query, [$location_id, $exclude_id, $fid]);
 }
+
+// ----------------------------------------------------------------------
+// Agent Availability
+// ----------------------------------------------------------------------
+
+function get_availability_statuses() {
+    return query_db("SELECT StatusID, ShortCode, StatusName, ColorCode FROM AvailabilityStatuses ORDER BY StatusID");
+}
+
+function get_availability_status_map() {
+    $rows = get_availability_statuses();
+    $map = [];
+    foreach ($rows as $r) {
+        $map[$r['StatusID']] = $r;
+    }
+    return $map;
+}
+
+function get_availability_for_agent($agent_id, $start_date, $end_date) {
+    $query = "SELECT Date, a.StatusID, s.ShortCode, s.ColorCode FROM AgentAvailability a JOIN AvailabilityStatuses s ON a.StatusID = s.StatusID WHERE a.AgentID = ? AND Date BETWEEN ? AND ?";
+    $rows = query_db($query, [$agent_id, $start_date, $end_date]);
+    $result = [];
+    foreach ($rows as $row) {
+        $result[$row['Date']] = $row;
+    }
+    return $result;
+}
+
+function upsert_agent_availability($agent_id, $date, $status_id) {
+    $db = get_db();
+    $stmt = $db->prepare('INSERT INTO AgentAvailability (AgentID, Date, StatusID) VALUES (?, ?, ?) ON CONFLICT(AgentID, Date) DO UPDATE SET StatusID=excluded.StatusID');
+    bind_params($stmt, [$agent_id, $date, $status_id]);
+    $stmt->execute();
+    $stmt->close();
+}
 ?>

--- a/php/static/css/style.css
+++ b/php/static/css/style.css
@@ -848,8 +848,59 @@ footer {
         margin-right: 0;
     }
     
-    .update-bubble.solution {
+.update-bubble.solution {
         margin-left: 0;
         margin-right: 0;
     }
+}
+
+/* ==============================================
+   VERFUEGBARKEITEN
+   ============================================== */
+
+.agent-box {
+    text-align: center;
+    margin: 0 0.3rem;
+}
+
+.week-boxes {
+    display: flex;
+    justify-content: center;
+    gap: 2px;
+    margin-bottom: 2px;
+}
+
+.day-box {
+    width: 10px;
+    height: 10px;
+    border: 1px solid #ccc;
+}
+
+.calendar-months {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.calendar-month {
+    border: 1px solid var(--border-color);
+    padding: 0.5rem;
+    font-size: 0.8rem;
+}
+
+.calendar-month table {
+    border-collapse: collapse;
+}
+
+.calendar-month td {
+    width: 24px;
+    height: 24px;
+    text-align: center;
+    color: #fff;
+    font-size: 0.7rem;
+}
+
+.availability-warning {
+    color: #dc3545;
+    font-weight: bold;
 }

--- a/php/templates/availability_edit.php
+++ b/php/templates/availability_edit.php
@@ -1,0 +1,36 @@
+<?php
+$title = 'Meine Verfügbarkeit - IFAK Ticketsystem';
+include 'templates/header.php';
+$month_names = ['Januar','Februar','März','April','Mai','Juni','Juli','August','September','Oktober','November','Dezember'];
+?>
+<h1>Meine Verfügbarkeit</h1>
+<form method="POST" action="index.php?action=edit_availability">
+<div class="calendar-months">
+<?php for ($m=0; $m<3; $m++): ?>
+    <?php $month_start = (clone $calendar_start)->modify("+$m month");
+          $month_end = (clone $month_start)->modify('last day of this month'); ?>
+    <div class="calendar-month">
+        <div class="month-name">
+            <?php echo $month_names[(int)$month_start->format('n')-1] . ' ' . $month_start->format('Y'); ?>
+        </div>
+        <table>
+            <tr>
+            <?php for ($d=1; $d <= (int)$month_end->format('j'); $d++): ?>
+                <?php $date = $month_start->format('Y-m-') . sprintf('%02d',$d);
+                      $current = $availability[$date]['StatusID'] ?? 1; ?>
+                <td>
+                    <select name="status[<?php echo $date; ?>]">
+                        <?php foreach ($statuses as $s): ?>
+                            <option value="<?php echo $s['StatusID']; ?>" <?php if ($current == $s['StatusID']) echo 'selected'; ?>><?php echo htmlspecialchars($s['ShortCode']); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </td>
+            <?php endfor; ?>
+            </tr>
+        </table>
+    </div>
+<?php endfor; ?>
+</div>
+<input type="submit" value="Speichern">
+</form>
+<?php include 'templates/footer.php'; ?>

--- a/php/templates/availability_overview.php
+++ b/php/templates/availability_overview.php
@@ -1,0 +1,42 @@
+<?php
+$title = 'Verfügbarkeiten - IFAK Ticketsystem';
+include 'templates/header.php';
+if (!isset($calendar_start)) {
+    $calendar_start = new DateTime('first day of this month', new DateTimeZone('Europe/Berlin'));
+    $calendar_end = (clone $calendar_start)->modify('+2 month')->modify('last day of this month');
+}
+$month_names = ['Januar','Februar','März','April','Mai','Juni','Juli','August','September','Oktober','November','Dezember'];
+?>
+<h1>Verfügbarkeiten</h1>
+<p><a href="index.php?action=edit_availability">Meine Verfügbarkeit bearbeiten</a></p>
+<?php foreach ($agents as $ag): ?>
+    <h2><?php echo htmlspecialchars($ag['AgentName']); ?></h2>
+    <?php $data = $avail_data[$ag['AgentID']] ?? []; ?>
+    <?php if (empty($data)): ?>
+        <div class="availability-warning">Keine Verfügbarkeiten hinterlegt!</div>
+    <?php endif; ?>
+    <div class="calendar-months">
+        <?php for ($m=0; $m<3; $m++): ?>
+            <?php $month_start = (clone $calendar_start)->modify("+$m month");
+                  $month_end = (clone $month_start)->modify('last day of this month'); ?>
+            <div class="calendar-month">
+                <div class="month-name">
+                    <?php echo $month_names[(int)$month_start->format('n')-1] . ' ' . $month_start->format('Y'); ?>
+                </div>
+                <table>
+                    <tr>
+                    <?php for ($d=1; $d <= (int)$month_end->format('j'); $d++): ?>
+                        <?php $date = $month_start->format('Y-m-') . sprintf('%02d', $d); 
+                              $color = $data[$date]['ColorCode'] ?? $status_map[1]['ColorCode'];
+                              $code = $data[$date]['ShortCode'] ?? $status_map[1]['ShortCode']; ?>
+                        <td style="background-color: <?php echo htmlspecialchars($color); ?>" title="<?php echo htmlspecialchars($code); ?>">
+                            <?php echo $d; ?>
+                        </td>
+                    <?php endfor; ?>
+                    </tr>
+                </table>
+            </div>
+        <?php endfor; ?>
+    </div>
+<?php endforeach; ?>
+<?php include 'templates/footer.php'; ?>

--- a/php/templates/header.php
+++ b/php/templates/header.php
@@ -3,6 +3,10 @@ if (!isset($title)) { $title = 'IFAK Ticketsystem'; }
 $base_url = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
 $php_base = $base_url;
 $css_version = filemtime(__DIR__ . '/../static/css/style.css');
+if (!isset($week1_dates)) $week1_dates = [];
+if (!isset($week2_dates)) $week2_dates = [];
+if (!isset($availability_overview)) $availability_overview = [];
+if (!isset($status_map)) $status_map = get_availability_status_map();
 ?>
 <!DOCTYPE html>
 <html lang="de">
@@ -20,16 +24,33 @@ $css_version = filemtime(__DIR__ . '/../static/css/style.css');
     <?php if (!empty($agents_overview)): ?>
     <div class="agent-overview">
         <?php foreach ($agents_overview as $ov): ?>
-            <a href="index.php?agent=<?php echo $ov['AgentID']; ?>" class="agent-link">
-                <?php echo htmlspecialchars($ov['AgentName']); ?>
-                (<?php echo $ov['OpenTickets']; ?>)
-            </a>
+            <div class="agent-box">
+                <div class="week-boxes">
+                    <?php foreach ($week1_dates as $d): ?>
+                        <?php $info = $availability_overview[$ov['AgentID']]['week1'][$d] ?? null; ?>
+                        <?php $color = $info['ColorCode'] ?? $status_map[1]['ColorCode']; ?>
+                        <span class="day-box" style="background-color: <?php echo htmlspecialchars($color); ?>"></span>
+                    <?php endforeach; ?>
+                </div>
+                <a href="index.php?agent=<?php echo $ov['AgentID']; ?>" class="agent-link">
+                    <?php echo htmlspecialchars($ov['AgentName']); ?>
+                    (<?php echo $ov['OpenTickets']; ?>)
+                </a>
+                <div class="week-boxes">
+                    <?php foreach ($week2_dates as $d): ?>
+                        <?php $info = $availability_overview[$ov['AgentID']]['week2'][$d] ?? null; ?>
+                        <?php $color = $info['ColorCode'] ?? $status_map[1]['ColorCode']; ?>
+                        <span class="day-box" style="background-color: <?php echo htmlspecialchars($color); ?>"></span>
+                    <?php endforeach; ?>
+                </div>
+            </div>
         <?php endforeach; ?>
     </div>
     <?php endif; ?>
     <nav>
         <ul>
             <li><a href="index.php">Dashboard</a></li>
+            <li><a href="index.php?action=availabilities">Verfügbarkeiten</a></li>
             <li><a href="index.php?action=new_ticket" class="button">+ Neues Ticket</a></li>
             <?php if (isset($agent)): ?>
             <li class="user-info">


### PR DESCRIPTION
## Summary
- support agent availability information
- expose availability in dashboard header
- add management pages for availability
- document how availability calendar works

## Testing
- `php -l php/index.php`
- `php -l php/models.php`
- `php -l php/templates/header.php`
- `php -l php/templates/availability_overview.php`
- `php -l php/templates/availability_edit.php`

------
https://chatgpt.com/codex/tasks/task_e_6883ce4e382c8327b0c452c24dda931e