### PR TITLE
Add inline availability editing

### DIFF
--- a/php/config.php
+++ b/php/config.php
@@ -22,4 +22,7 @@ $UNASSIGNED_WARNING_HOURS = [
     2 => 4, // Mittel
     1 => 8  // Niedrig
 ];
+
+// ID des Auszubildenden für spezielle Verfügbarkeitsoptionen
+$TRAINEE_AGENT_ID = 5;
 ?>

--- a/php/index.php
+++ b/php/index.php
@@ -57,6 +57,17 @@ if ($action === 'logout') {
     exit;
 }
 
+if ($action === 'set_availability') {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        $date = $_POST['date'] ?? '';
+        $status_id = intval($_POST['status_id'] ?? 1);
+        if ($date) {
+            upsert_agent_availability($agent['AgentID'], $date, $status_id);
+        }
+    }
+    exit;
+}
+
 if ($action === 'availabilities') {
     $calendar_start = new DateTime('first day of this month', new DateTimeZone('Europe/Berlin'));
     $calendar_end = (clone $calendar_start)->modify('+2 month')->modify('last day of this month');

--- a/php/models.php
+++ b/php/models.php
@@ -15,11 +15,11 @@ function get_all_priorities() {
 }
 
 function load_agents() {
-    return query_db("SELECT a.AgentID, a.AgentName, a.AgentEmail, a.Token, a.Active, a.TeamID, t.TeamName, t.TeamColor FROM Agents a JOIN Teams t ON a.TeamID = t.TeamID WHERE a.Active = 1 ORDER BY a.AgentName");
+    return query_db("SELECT a.AgentID, a.AgentName, a.AgentEmail, a.Token, a.Active, a.IsTrainee, a.TeamID, t.TeamName, t.TeamColor FROM Agents a JOIN Teams t ON a.TeamID = t.TeamID WHERE a.Active = 1 ORDER BY a.AgentName");
 }
 
 function get_agent_by_token($token) {
-    return query_db("SELECT a.AgentID, a.AgentName, a.AgentEmail, a.Token, a.Active, a.TeamID, t.TeamName, t.TeamColor FROM Agents a JOIN Teams t ON a.TeamID = t.TeamID WHERE a.Token = ? AND a.Active = 1", [$token], true);
+    return query_db("SELECT a.AgentID, a.AgentName, a.AgentEmail, a.Token, a.Active, a.IsTrainee, a.TeamID, t.TeamName, t.TeamColor FROM Agents a JOIN Teams t ON a.TeamID = t.TeamID WHERE a.Token = ? AND a.Active = 1", [$token], true);
 }
 
 function get_agents_with_ticket_counts() {

--- a/php/static/css/style.css
+++ b/php/static/css/style.css
@@ -882,6 +882,16 @@ footer {
     flex-wrap: wrap;
 }
 
+.agent-columns {
+    display: flex;
+    gap: 1rem;
+    overflow-x: auto;
+}
+
+.agent-column {
+    min-width: 260px;
+}
+
 .calendar-month {
     border: 1px solid var(--border-color);
     padding: 0.5rem;
@@ -898,6 +908,11 @@ footer {
     text-align: center;
     color: #fff;
     font-size: 0.7rem;
+}
+
+.calendar-month td.weekend {
+    background-color: #ccc !important;
+    color: #666;
 }
 
 .availability-warning {

--- a/php/templates/availability_overview.php
+++ b/php/templates/availability_overview.php
@@ -8,35 +8,73 @@ if (!isset($calendar_start)) {
 $month_names = ['Januar','Februar','März','April','Mai','Juni','Juli','August','September','Oktober','November','Dezember'];
 ?>
 <h1>Verfügbarkeiten</h1>
-<p><a href="index.php?action=edit_availability">Meine Verfügbarkeit bearbeiten</a></p>
+<p>Klick auf einen Tag, um die eigene Verfügbarkeit zu ändern.</p>
+<div class="agent-columns">
 <?php foreach ($agents as $ag): ?>
-    <h2><?php echo htmlspecialchars($ag['AgentName']); ?></h2>
     <?php $data = $avail_data[$ag['AgentID']] ?? []; ?>
-    <?php if (empty($data)): ?>
-        <div class="availability-warning">Keine Verfügbarkeiten hinterlegt!</div>
-    <?php endif; ?>
-    <div class="calendar-months">
-        <?php for ($m=0; $m<3; $m++): ?>
-            <?php $month_start = (clone $calendar_start)->modify("+$m month");
-                  $month_end = (clone $month_start)->modify('last day of this month'); ?>
-            <div class="calendar-month">
-                <div class="month-name">
-                    <?php echo $month_names[(int)$month_start->format('n')-1] . ' ' . $month_start->format('Y'); ?>
+    <div class="agent-column">
+        <h2><?php echo htmlspecialchars($ag['AgentName']); ?></h2>
+        <?php if (empty($data)): ?>
+            <div class="availability-warning">Keine Verfügbarkeiten hinterlegt!</div>
+        <?php endif; ?>
+        <div class="calendar-months">
+            <?php for ($m=0; $m<3; $m++): ?>
+                <?php $month_start = (clone $calendar_start)->modify("+$m month");
+                      $month_end = (clone $month_start)->modify('last day of this month'); ?>
+                <div class="calendar-month">
+                    <div class="month-name">
+                        <?php echo $month_names[(int)$month_start->format('n')-1] . ' ' . $month_start->format('Y'); ?>
+                    </div>
+                    <table>
+                        <?php $week_start = (clone $month_start)->modify('monday this week'); ?>
+                        <?php while ($week_start <= $month_end): ?>
+                            <tr>
+                            <?php for ($i=0; $i<7; $i++): ?>
+                                <?php $date = $week_start->format('Y-m-d');
+                                      $day_num = (int)$week_start->format('j');
+                                      $in_month = $week_start->format('m') === $month_start->format('m');
+                                      $dow = (int)$week_start->format('N');
+                                      $status = $data[$date]['StatusID'] ?? null;
+                                      $color = $status ? ($status_map[$status]['ColorCode']) : '#000000';
+                                      $code = $status ? ($status_map[$status]['ShortCode']) : ''; ?>
+                                <td class="<?php echo $dow>=6 ? 'weekend' : ''; ?> availability-day" data-date="<?php echo $date; ?>" data-status="<?php echo $status ?: 0; ?>" data-agent="<?php echo $ag['AgentID']; ?>" style="background-color: <?php echo $in_month ? htmlspecialchars($color) : '#eee'; ?>" title="<?php echo htmlspecialchars($code); ?>">
+                                    <?php echo $in_month ? $day_num : '&nbsp;'; ?>
+                                </td>
+                                <?php $week_start->modify('+1 day'); ?>
+                            <?php endfor; ?>
+                            </tr>
+                        <?php endwhile; ?>
+                    </table>
                 </div>
-                <table>
-                    <tr>
-                    <?php for ($d=1; $d <= (int)$month_end->format('j'); $d++): ?>
-                        <?php $date = $month_start->format('Y-m-') . sprintf('%02d', $d); 
-                              $color = $data[$date]['ColorCode'] ?? $status_map[1]['ColorCode'];
-                              $code = $data[$date]['ShortCode'] ?? $status_map[1]['ShortCode']; ?>
-                        <td style="background-color: <?php echo htmlspecialchars($color); ?>" title="<?php echo htmlspecialchars($code); ?>">
-                            <?php echo $d; ?>
-                        </td>
-                    <?php endfor; ?>
-                    </tr>
-                </table>
-            </div>
-        <?php endfor; ?>
-    </div>
+            <?php endfor; ?>
+        </div>
+</div>
 <?php endforeach; ?>
+</div>
+<script>
+const statusMap = <?php echo json_encode($status_map); ?>;
+const traineeId = <?php echo json_encode($TRAINEE_AGENT_ID); ?>;
+document.querySelectorAll('.availability-day').forEach(function(td){
+    if(td.classList.contains('weekend')) return;
+    td.addEventListener('click', function(){
+        let current = parseInt(td.dataset.status);
+        const agentId = parseInt(td.dataset.agent);
+        let next;
+        if(!current || current === statusMap[1].StatusID){
+            next = statusMap[2].StatusID;
+        } else if(current === statusMap[2].StatusID){
+            next = (agentId === traineeId) ? statusMap[4].StatusID : statusMap[3].StatusID;
+        } else {
+            next = statusMap[1].StatusID;
+        }
+        td.dataset.status = next;
+        td.style.backgroundColor = statusMap[next].ColorCode;
+        fetch('index.php?action=set_availability', {
+            method:'POST',
+            headers:{'Content-Type':'application/x-www-form-urlencoded'},
+            body:'date=' + encodeURIComponent(td.dataset.date) + '&status_id=' + next
+        });
+    });
+});
+</script>
 <?php include 'templates/footer.php'; ?>

--- a/php/templates/header.php
+++ b/php/templates/header.php
@@ -28,7 +28,7 @@ if (!isset($status_map)) $status_map = get_availability_status_map();
                 <div class="week-boxes">
                     <?php foreach ($week1_dates as $d): ?>
                         <?php $info = $availability_overview[$ov['AgentID']]['week1'][$d] ?? null; ?>
-                        <?php $color = $info['ColorCode'] ?? $status_map[1]['ColorCode']; ?>
+                        <?php $color = $info ? $info['ColorCode'] : '#000000'; ?>
                         <span class="day-box" style="background-color: <?php echo htmlspecialchars($color); ?>"></span>
                     <?php endforeach; ?>
                 </div>
@@ -39,7 +39,7 @@ if (!isset($status_map)) $status_map = get_availability_status_map();
                 <div class="week-boxes">
                     <?php foreach ($week2_dates as $d): ?>
                         <?php $info = $availability_overview[$ov['AgentID']]['week2'][$d] ?? null; ?>
-                        <?php $color = $info['ColorCode'] ?? $status_map[1]['ColorCode']; ?>
+                        <?php $color = $info ? $info['ColorCode'] : '#000000'; ?>
                         <span class="day-box" style="background-color: <?php echo htmlspecialchars($color); ?>"></span>
                     <?php endforeach; ?>
                 </div>


### PR DESCRIPTION
## Summary
- color agent header cells black when no availability is stored
- allow modifying availability directly from the overview
- cycle through vacation, school/sick and available on click
- restrict "school" option to trainee
- tweak calendar layout and style

## Testing
- `php -l php/templates/availability_overview.php`
- `php -l php/templates/header.php`
- `php -l php/index.php`
- `php -l php/models.php`
- `php -l php/config.php`


------
https://chatgpt.com/codex/tasks/task_e_688644f5c0a88327846b31e1cc19509a