### PR TITLE
Update JS for agent-specific availability editing

### DIFF
--- a/php/templates/availability_overview.php
+++ b/php/templates/availability_overview.php
@@ -54,8 +54,10 @@ $month_names = ['Januar','Februar','März','April','Mai','Juni','Juli','August',
 <script>
 const statusMap = <?php echo json_encode($status_map); ?>;
 const traineeId = <?php echo json_encode($TRAINEE_AGENT_ID); ?>;
+const currentAgent = <?php echo json_encode($agent['AgentID']); ?>;
 document.querySelectorAll('.availability-day').forEach(function(td){
     if(td.classList.contains('weekend')) return;
+    if(parseInt(td.dataset.agent) !== currentAgent) return;
     td.addEventListener('click', function(){
         let current = parseInt(td.dataset.status);
         const agentId = parseInt(td.dataset.agent);


### PR DESCRIPTION
## Summary
- expose current agent ID in availability overview
- restrict inline availability editing to the current agent

## Testing
- `php -l php/templates/availability_overview.php`

------
https://chatgpt.com/codex/tasks/task_e_68864d2299c08327a70bb3bcb31906bd