### PR TITLE
Add legend to agent availability page

### DIFF
--- a/php/static/css/style.css
+++ b/php/static/css/style.css
@@ -919,3 +919,23 @@ footer {
     color: #dc3545;
     font-weight: bold;
 }
+
+.availability-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    margin-bottom: 1rem;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.8rem;
+}
+
+.legend-box {
+    width: 12px;
+    height: 12px;
+    border: 1px solid #ccc;
+}

--- a/php/templates/availability_overview.php
+++ b/php/templates/availability_overview.php
@@ -9,6 +9,14 @@ $month_names = ['Januar','Februar','März','April','Mai','Juni','Juli','August',
 ?>
 <h1>Verfügbarkeiten</h1>
 <p>Klick auf einen Tag, um die eigene Verfügbarkeit zu ändern.</p>
+<div class="availability-legend">
+    <?php foreach ($status_map as $st): ?>
+    <div class="legend-item">
+        <span class="legend-box" style="background-color: <?php echo htmlspecialchars($st['ColorCode']); ?>"></span>
+        <span><?php echo htmlspecialchars($st['StatusName']); ?></span>
+    </div>
+    <?php endforeach; ?>
+</div>
 <div class="agent-columns">
 <?php foreach ($agents as $ag): ?>
     <?php $data = $avail_data[$ag['AgentID']] ?? []; ?>


### PR DESCRIPTION
## Summary
- show availability status legend on `availability_overview.php`
- style legend elements in `style.css`

## Testing
- `php -l php/templates/availability_overview.php`

------
https://chatgpt.com/codex/tasks/task_e_68865604bbd083278041d27a09855a1e