### PR TITLE
Improve availability legend layout

### DIFF
--- a/php/static/css/style.css
+++ b/php/static/css/style.css
@@ -852,6 +852,12 @@ footer {
         margin-left: 0;
         margin-right: 0;
     }
+    .availability-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+
 }
 
 /* ==============================================
@@ -919,7 +925,13 @@ footer {
     color: #dc3545;
     font-weight: bold;
 }
-
+.availability-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+}
 .availability-legend {
     display: flex;
     flex-wrap: wrap;
@@ -931,11 +943,11 @@ footer {
     display: flex;
     align-items: center;
     gap: 0.25rem;
-    font-size: 0.8rem;
+    font-size: 1rem;
 }
 
 .legend-box {
-    width: 12px;
-    height: 12px;
+    width: 18px;
+    height: 18px;
     border: 1px solid #ccc;
 }

--- a/php/templates/availability_overview.php
+++ b/php/templates/availability_overview.php
@@ -7,16 +7,18 @@ if (!isset($calendar_start)) {
 }
 $month_names = ['Januar','Februar','März','April','Mai','Juni','Juli','August','September','Oktober','November','Dezember'];
 ?>
-<h1>Verfügbarkeiten</h1>
-<p>Klick auf einen Tag, um die eigene Verfügbarkeit zu ändern.</p>
-<div class="availability-legend">
-    <?php foreach ($status_map as $st): ?>
-    <div class="legend-item">
-        <span class="legend-box" style="background-color: <?php echo htmlspecialchars($st['ColorCode']); ?>"></span>
-        <span><?php echo htmlspecialchars($st['StatusName']); ?></span>
+<div class="availability-header">
+    <h1>Verfügbarkeiten</h1>
+    <div class="availability-legend">
+        <?php foreach ($status_map as $st): ?>
+        <div class="legend-item">
+            <span class="legend-box" style="background-color: <?php echo htmlspecialchars($st['ColorCode']); ?>"></span>
+            <span><?php echo htmlspecialchars($st['StatusName']); ?></span>
+        </div>
+        <?php endforeach; ?>
     </div>
-    <?php endforeach; ?>
 </div>
+<p>Klick auf einen Tag, um die eigene Verfügbarkeit zu ändern.</p>
 <div class="agent-columns">
 <?php foreach ($agents as $ag): ?>
     <?php $data = $avail_data[$ag['AgentID']] ?? []; ?>


### PR DESCRIPTION
## Summary
- show legend next to heading on desktop
- enlarge availability legend boxes and text

## Testing
- `php -l php/templates/availability_overview.php`

------
https://chatgpt.com/codex/tasks/task_e_68865877d21083278383c655449551ef