### PR TITLE
Implement email notification for ticket assignments

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -44,4 +44,29 @@ function get_addressbook_date() {
         return 'Nicht verfügbar';
     }
 }
+
+function get_base_url() {
+    $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') ? 'https' : 'http';
+    $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+    $path = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
+    return $scheme . '://' . $host . $path;
+}
+
+function send_assignment_email($agent_email, $agent_name, $ticket) {
+    if (!$agent_email) return;
+    $base_url = get_base_url();
+    $link = $base_url . '/index.php?action=view_ticket&id=' . $ticket['TicketID'];
+    $subject = 'Ticket #' . $ticket['TicketID'] . ' zugewiesen';
+    $priority = $ticket['PriorityName'] ?? '';
+    $body = "Hallo $agent_name,\n\n" .
+            "Ihnen wurde ein neues Ticket zugewiesen:\n" .
+            "Titel: {$ticket['Title']}\n" .
+            ($priority ? "Priorität: $priority\n" : '') .
+            "Kontakt: {$ticket['ContactName']}\n" .
+            ($ticket['ContactPhone'] ? "Telefon: {$ticket['ContactPhone']}\n" : '') .
+            ($ticket['ContactEmail'] ? "E-Mail: {$ticket['ContactEmail']}\n" : '') .
+            "\nZum Ticket: $link\n\n" .
+            "Beschreibung:\n{$ticket['Description']}\n";
+    @mail($agent_email, $subject, $body, "From: helpdesk@ifak-sozial.de");
+}
 ?>

--- a/php/index.php
+++ b/php/index.php
@@ -119,12 +119,25 @@ if ($action === 'new_ticket') {
 
         $assigned_agent = $_POST['assigned_agent'] ?? '';
         if ($assigned_agent) {
-            $info = query_db('SELECT AgentName FROM Agents WHERE AgentID = ?', [$assigned_agent], true);
+            $info = query_db('SELECT AgentName, AgentEmail FROM Agents WHERE AgentID = ?', [$assigned_agent], true);
             if ($info) {
                 insert_db('TicketAssignees', ['TicketID','AgentID','AgentName','AssignedAt'], [$ticket_id,$assigned_agent,$info['AgentName'],get_local_timestamp()]);
                 $assign_time = (new DateTime('now', new DateTimeZone('Europe/Berlin')))->format('d.m.Y H:i');
                 $assign_note = $agent['AgentName'] . ' hat am ' . $assign_time . ' ' . $info['AgentName'] . ' zugewiesen.';
                 insert_db('TicketUpdates', ['TicketID','UpdatedByName','UpdateText','IsSolution','UpdatedAt'], [$ticket_id,$agent['AgentName'],$assign_note,0,get_local_timestamp()]);
+
+                $prio = get_priority_by_id($priority_id);
+                $ticket_info = [
+                    'TicketID' => $ticket_id,
+                    'Title' => $title,
+                    'Description' => $description,
+                    'PriorityID' => $priority_id,
+                    'PriorityName' => $prio['PriorityName'] ?? '',
+                    'ContactName' => $contact_name,
+                    'ContactPhone' => $contact_phone,
+                    'ContactEmail' => $contact_email
+                ];
+                send_assignment_email($info['AgentEmail'], $info['AgentName'], $ticket_info);
             }
         }
         if (!empty($_FILES['attachment']['name']) && allowed_file($_FILES['attachment']['name'])) {
@@ -176,7 +189,7 @@ if ($action === 'update_ticket') {
             if ($assign_agent) {
                 $existing = query_db('SELECT 1 FROM TicketAssignees WHERE TicketID = ? AND AgentID = ?', [$ticket_id, $assign_agent], true);
                 if (!$existing) {
-                    $info = query_db('SELECT AgentName FROM Agents WHERE AgentID = ?', [$assign_agent], true);
+                    $info = query_db('SELECT AgentName, AgentEmail FROM Agents WHERE AgentID = ?', [$assign_agent], true);
                     if ($info) {
                         insert_db('TicketAssignees', ['TicketID','AgentID','AgentName','AssignedAt'], [$ticket_id,$assign_agent,$info['AgentName'],get_local_timestamp()]);
                         $assign_time = (new DateTime('now', new DateTimeZone('Europe/Berlin')))->format('d.m.Y H:i');
@@ -186,6 +199,20 @@ if ($action === 'update_ticket') {
                         } else {
                             $update_text .= "\n\n" . $assign_note;
                         }
+
+                        $p_id = $priority_id ?: $ticket['PriorityID'];
+                        $prio = get_priority_by_id($p_id);
+                        $ticket_info = [
+                            'TicketID' => $ticket_id,
+                            'Title' => $ticket['Title'],
+                            'Description' => $ticket['Description'],
+                            'PriorityID' => $p_id,
+                            'PriorityName' => $prio['PriorityName'] ?? '',
+                            'ContactName' => $ticket['ContactName'],
+                            'ContactPhone' => $ticket['ContactPhone'],
+                            'ContactEmail' => $ticket['ContactEmail']
+                        ];
+                        send_assignment_email($info['AgentEmail'], $info['AgentName'], $ticket_info);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add helper to build base URL and dispatch assignment emails
- send mail when assigning an agent during ticket creation
- send mail when assigning an agent on ticket update

## Testing
- `php -l php/helpers.php`
- `php -l php/index.php`


------
https://chatgpt.com/codex/tasks/task_e_688658e663f08327a313f981ac236781