### PR TITLE
Improve mobile layout

### DIFF
--- a/php/static/css/style.css
+++ b/php/static/css/style.css
@@ -51,6 +51,11 @@ header {
     text-decoration: none;
 }
 
+.logo img {
+    max-width: 200px;
+    height: auto;
+}
+
 nav ul {
     display: flex;
     list-style: none;
@@ -211,6 +216,10 @@ main {
 .search-group .search-bar input {
     flex: 1;
     width: auto;
+}
+
+.dashboard-table {
+    overflow-x: auto;
 }
 .assigned-agents {
     font-size: 0.9em;
@@ -819,6 +828,20 @@ footer {
     
     .form-row {
         flex-direction: column;
+    }
+
+    .ticket-form,
+    .login-box {
+        max-width: 100%;
+        padding: 1rem;
+    }
+
+    .dashboard-table table {
+        min-width: 600px;
+    }
+
+    .logo img {
+        max-width: 150px;
     }
     
     nav ul {

--- a/php/templates/header.php
+++ b/php/templates/header.php
@@ -19,7 +19,7 @@ if (!isset($status_map)) $status_map = get_availability_status_map();
 <body>
 <header>
     <div class="logo">
-        <a href="index.php"><img src="<?php echo $base_url; ?>/static/img/ifak-ticket-logo.svg" alt="IFAK Logo" width="300"></a>
+        <a href="index.php"><img src="<?php echo $base_url; ?>/static/img/ifak-ticket-logo.svg" alt="IFAK Logo" width="200"></a>
     </div>
     <?php if (!empty($agents_overview)): ?>
     <div class="agent-overview">


### PR DESCRIPTION
## Summary
- scale header logo via CSS
- add overflow to dashboard table
- tweak forms and table width for small screens
- reduce logo width in header template

## Testing
- `find php/templates -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_688852df650c83278a05c025010e8b8b