### PR TITLE
Add automatic link detection in ticket details

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -52,6 +52,12 @@ function get_base_url() {
     return $scheme . '://' . $host . $path;
 }
 
+function linkify_urls($text) {
+    $escaped = htmlspecialchars($text);
+    $pattern = '/(https:\/\/[^\s]+)/';
+    return preg_replace($pattern, '<a href="$1" target="_blank" rel="noopener">$1</a>', $escaped);
+}
+
 function send_new_ticket_email($ticket) {
     global $HELPDESK_FUNCTIONAL, $HELPDESK_FROM;
     $base_url = get_base_url();

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -139,14 +139,14 @@
         <div class="ticket-details">
             <h3>Beschreibung</h3>
             <div class="description-bubble">
-                <div class="bubble-content"><?php echo htmlspecialchars($ticket['Description']); ?></div>
+                <div class="bubble-content"><?php echo linkify_urls($ticket['Description']); ?></div>
             </div>
 
             <h3>Verlauf</h3>
             <div class="updates-list">
                 <?php foreach ($updates as $u): ?>
                 <div class="update-bubble <?php if ($u['IsSolution']) echo 'solution'; ?>">
-                    <div class="bubble-content"><?php echo htmlspecialchars($u['UpdateText']); ?></div>
+                    <div class="bubble-content"><?php echo linkify_urls($u['UpdateText']); ?></div>
                     <div class="bubble-meta">
                         <span class="bubble-author"><?php echo htmlspecialchars($u['UpdatedByName']); ?></span>
                         <span class="bubble-time"><?php echo $u['FormattedUpdatedAt']; ?></span>


### PR DESCRIPTION
## Summary
- enhance helpers with `linkify_urls` for automatic hyperlink creation
- use `linkify_urls` for ticket descriptions and update texts

## Testing
- `php -l php/helpers.php`
- `php -l php/templates/ticket_view.php`


------
https://chatgpt.com/codex/tasks/task_e_688cf42a38c483279804b3721cba63f3