### PR TITLE
Improve ticket notifications and roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,6 +42,8 @@
 - Benachrichtigung der Agenten per EMail bei:
   - Neuen Tickets (Funktions-Postfach helpdesk@ifak-sozial.de)
   - Ticket-Zuweisungen (individuelle Mail) mit Angabe der Reaktionszeit, die sich aus der Priorität ableitet.
+- Benachrichtigung bei gelösten Tickets an Qualitätskontrolle und Ticket-Ersteller (Platzhalter helpdesk@ifak-sozial.de)
+- Prioritätsstufe "HOT" für Tickets mit sofortigem Handlungsbedarf
 
 ---
 

--- a/php/config.php
+++ b/php/config.php
@@ -32,6 +32,9 @@ $HELPDESK_FROM = 'helpdesk@ifak-bochum.de';
 // Funktions-Postfach für neue Tickets
 $HELPDESK_FUNCTIONAL = 'helpdesk@ifak-sozial.de';
 
+// Empfänger für gelöste Tickets (Qualitätskontrolle)
+$QUALITY_CONTROL_EMAIL = 'helpdesk@ifak-bochum.de';
+
 // Reaktionszeiten pro Priorität (in Stunden)
 $REACTION_TIME_HOURS = [
     3 => 2, // Hoch

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -95,4 +95,30 @@ function send_assignment_email($agent_email, $agent_name, $ticket) {
             "Beschreibung:\n{$ticket['Description']}\n";
     @mail($agent_email, $subject, $body, "From: $HELPDESK_FROM");
 }
+
+function send_solution_email($ticket, $updates) {
+    global $QUALITY_CONTROL_EMAIL, $HELPDESK_FROM;
+    $base_url = get_base_url();
+    $link = $base_url . '/index.php?action=view_ticket&id=' . $ticket['TicketID'];
+    $subject = 'Ticket #' . $ticket['TicketID'] . ' gelöst';
+    $body = 'Ticket #' . $ticket['TicketID'] . " wurde als gelöst markiert.\n\n" .
+            "Aufgabenstellung:\n{$ticket['Description']}\n\n" .
+            "Kommentarhistorie:\n";
+    $history = array_reverse($updates);
+    foreach ($history as $u) {
+        $prefix = $u['IsSolution'] ? '[Lösung] ' : '';
+        $body .= $prefix . $u['UpdatedByName'] . ' (' . $u['FormattedUpdatedAt'] . "):\n" .
+                 $u['UpdateText'] . "\n\n";
+    }
+    $body .= "Zum Ticket: $link\n";
+
+    if (!empty($QUALITY_CONTROL_EMAIL)) {
+        @mail($QUALITY_CONTROL_EMAIL, $subject, $body, "From: $HELPDESK_FROM");
+    }
+    $submitter = 'helpdesk@ifak-sozial.de'; // Platzhalter für die aufgebende Person
+    // $submitter = $ticket['ContactEmail'];
+    if ($submitter) {
+        @mail($submitter, $subject, $body, "From: $HELPDESK_FROM");
+    }
+}
 ?>

--- a/php/index.php
+++ b/php/index.php
@@ -200,38 +200,46 @@ if ($action === 'update_ticket') {
             }
 
             if ($assign_agent) {
-                $existing = query_db('SELECT 1 FROM TicketAssignees WHERE TicketID = ? AND AgentID = ?', [$ticket_id, $assign_agent], true);
-                if (!$existing) {
-                    $info = query_db('SELECT AgentName, AgentEmail FROM Agents WHERE AgentID = ?', [$assign_agent], true);
-                    if ($info) {
+                $info = query_db('SELECT AgentName, AgentEmail FROM Agents WHERE AgentID = ?', [$assign_agent], true);
+                if ($info) {
+                    $existing = query_db('SELECT 1 FROM TicketAssignees WHERE TicketID = ? AND AgentID = ?', [$ticket_id, $assign_agent], true);
+                    if (!$existing) {
                         insert_db('TicketAssignees', ['TicketID','AgentID','AgentName','AssignedAt'], [$ticket_id,$assign_agent,$info['AgentName'],get_local_timestamp()]);
-                        $assign_time = (new DateTime('now', new DateTimeZone('Europe/Berlin')))->format('d.m.Y H:i');
-                        $assign_note = $agent['AgentName'] . ' hat am ' . $assign_time . ' ' . $info['AgentName'] . ' zugewiesen.';
-                        if ($update_text === '') {
-                            $update_text = $assign_note;
-                        } else {
-                            $update_text .= "\n\n" . $assign_note;
-                        }
-
-                        $p_id = $priority_id ?: $ticket['PriorityID'];
-                        $prio = get_priority_by_id($p_id);
-                        $ticket_info = [
-                            'TicketID' => $ticket_id,
-                            'Title' => $ticket['Title'],
-                            'Description' => $ticket['Description'],
-                            'PriorityID' => $p_id,
-                            'PriorityName' => $prio['PriorityName'] ?? '',
-                            'ContactName' => $ticket['ContactName'],
-                            'ContactPhone' => $ticket['ContactPhone'],
-                            'ContactEmail' => $ticket['ContactEmail']
-                        ];
-                        send_assignment_email($info['AgentEmail'], $info['AgentName'], $ticket_info);
+                    } else {
+                        query_db('UPDATE TicketAssignees SET AssignedAt = ? WHERE TicketID = ? AND AgentID = ?', [get_local_timestamp(), $ticket_id, $assign_agent]);
                     }
+                    $assign_time = (new DateTime('now', new DateTimeZone('Europe/Berlin')))->format('d.m.Y H:i');
+                    $assign_note = $agent['AgentName'] . ' hat am ' . $assign_time . ' ' . $info['AgentName'] . ' zugewiesen.';
+                    if ($update_text === '') {
+                        $update_text = $assign_note;
+                    } else {
+                        $update_text .= "\n\n" . $assign_note;
+                    }
+
+                    $p_id = $priority_id ?: $ticket['PriorityID'];
+                    $prio = get_priority_by_id($p_id);
+                    $ticket_info = [
+                        'TicketID' => $ticket_id,
+                        'Title' => $ticket['Title'],
+                        'Description' => $ticket['Description'],
+                        'PriorityID' => $p_id,
+                        'PriorityName' => $prio['PriorityName'] ?? '',
+                        'ContactName' => $ticket['ContactName'],
+                        'ContactPhone' => $ticket['ContactPhone'],
+                        'ContactEmail' => $ticket['ContactEmail']
+                    ];
+                    send_assignment_email($info['AgentEmail'], $info['AgentName'], $ticket_info);
                 }
             }
 
             if ($update_text !== '' || $is_solution) {
                 insert_db('TicketUpdates', ['TicketID','UpdatedByName','UpdateText','IsSolution','UpdatedAt'], [$ticket_id,$agent['AgentName'],$update_text,$is_solution,get_local_timestamp()]);
+            }
+
+            if ($is_solution) {
+                $ticket_mail = get_ticket_by_id($ticket_id);
+                $updates_mail = get_ticket_updates($ticket_id);
+                send_solution_email($ticket_mail, $updates_mail);
             }
 
             if (!empty($_FILES['attachment']['name']) && allowed_file($_FILES['attachment']['name'])) {


### PR DESCRIPTION
## Summary
- Send assignment emails on every reassignment
- Notify quality control and ticket creator when marking tickets as solved
- Document HOT priority and solution emails in roadmap

## Testing
- `php -l php/config.php`
- `php -l php/helpers.php`
- `php -l php/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa1956f0188327945b3ee93a904970