### PR TITLE
Include ticket creation time in assignment emails

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -83,11 +83,22 @@ function send_assignment_email($agent_email, $agent_name, $ticket) {
     $priority = $ticket['PriorityName'] ?? '';
     global $REACTION_TIME_HOURS, $HELPDESK_FROM;
     $reaction = $ticket['PriorityID'] ? ($REACTION_TIME_HOURS[$ticket['PriorityID']] ?? null) : null;
+    $remaining = null;
+    if ($reaction && !empty($ticket['CreatedAt'])) {
+        try {
+            $created = new DateTime($ticket['CreatedAt'], new DateTimeZone('Europe/Berlin'));
+            $now = new DateTime('now', new DateTimeZone('Europe/Berlin'));
+            $elapsed = ($now->getTimestamp() - $created->getTimestamp()) / 3600;
+            $remaining = max(0, $reaction - $elapsed);
+            $remaining = round($remaining);
+        } catch (Exception $e) {}
+    }
     $body = "Hallo $agent_name,\n\n" .
             "Dir wurde ein neues Ticket zugewiesen:\n" .
             "Titel: {$ticket['Title']}\n" .
             ($priority ? "Priorität: $priority\n" : '') .
             ($reaction ? "Reaktionszeit: {$reaction}h\n" : '') .
+            ($remaining !== null ? "Reaktionszeit verbleibend: {$remaining}h\n" : '') .
             "Kontakt: {$ticket['ContactName']}\n" .
             ($ticket['ContactPhone'] ? "Telefon: {$ticket['ContactPhone']}\n" : '') .
             ($ticket['ContactEmail'] ? "E-Mail: {$ticket['ContactEmail']}\n" : '') .

--- a/php/index.php
+++ b/php/index.php
@@ -112,9 +112,10 @@ if ($action === 'new_ticket') {
         $location_id = $_POST['location_id'] ?? null;
         $department_id = $_POST['department_id'] ?? null;
         $source = $_POST['source'] ?? null;
+        $created_at = get_local_timestamp();
         $ticket_id = insert_db('Tickets',
             ['Title','Description','PriorityID','TeamID','StatusID','CreatedAt','CreatedByAgentID','Source','ContactName','ContactPhone','ContactEmail','ContactEmployeeID','FacilityID','LocationID','DepartmentID'],
-            [$title,$description,$priority_id,$team_id,1,get_local_timestamp(),$agent['AgentID'],$source,$contact_name,$contact_phone,$contact_email,$contact_employee_id,$facility_id,$location_id,$department_id]
+            [$title,$description,$priority_id,$team_id,1,$created_at,$agent['AgentID'],$source,$contact_name,$contact_phone,$contact_email,$contact_employee_id,$facility_id,$location_id,$department_id]
         );
 
         $prio = get_priority_by_id($priority_id);
@@ -148,7 +149,8 @@ if ($action === 'new_ticket') {
                     'PriorityName' => $prio['PriorityName'] ?? '',
                     'ContactName' => $contact_name,
                     'ContactPhone' => $contact_phone,
-                    'ContactEmail' => $contact_email
+                    'ContactEmail' => $contact_email,
+                    'CreatedAt' => $created_at
                 ];
                 send_assignment_email($info['AgentEmail'], $info['AgentName'], $ticket_info);
             }
@@ -226,7 +228,8 @@ if ($action === 'update_ticket') {
                         'PriorityName' => $prio['PriorityName'] ?? '',
                         'ContactName' => $ticket['ContactName'],
                         'ContactPhone' => $ticket['ContactPhone'],
-                        'ContactEmail' => $ticket['ContactEmail']
+                        'ContactEmail' => $ticket['ContactEmail'],
+                        'CreatedAt' => $ticket['CreatedAt']
                     ];
                     send_assignment_email($info['AgentEmail'], $info['AgentName'], $ticket_info);
                 }


### PR DESCRIPTION
## Summary
- Pass ticket creation timestamps through assignment email calls.
- Expand assignment email helper to compute and show remaining reaction time.

## Testing
- `php -l php/index.php`
- `php -l php/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68afe55f0ff08327914bd3995619ebae