### PR TITLE
Add cron script to notify about unassigned tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,13 @@ Funktionsfähige Beta
 - REST‑ähnliche APIs – Endpunkte für Ticket- und Mitarbeitersuche sowie Detailabruf eines Mitarbeiters.
 - Service Worker für Benachrichtigungen – Registrierung eines Service Workers in main.js für Push-Benachrichtigungen.
 
+## Cronjob
+Unzugewiesene Tickets können automatisch gemeldet werden. Dazu folgenden Cronjob einrichten:
+
+```
+*/15 * * * * php /pfad/zum/notify_unassigned.php
+```
+
 ## Kontakt
 IFAK e.V. - IT-Abteilung
+

--- a/php/cron/notify_unassigned.php
+++ b/php/cron/notify_unassigned.php
@@ -1,0 +1,48 @@
+<?php
+require_once __DIR__ . '/../models.php';
+
+$now = new DateTime('now', new DateTimeZone('Europe/Berlin'));
+$today = $now->format('Y-m-d');
+
+// Unassigned open tickets
+$query = "SELECT t.TicketID, t.Title, t.PriorityID, p.PriorityName, t.CreatedAt " .
+         "FROM Tickets t " .
+         "JOIN TicketPriorities p ON t.PriorityID = p.PriorityID " .
+         "JOIN TicketStatus s ON t.StatusID = s.StatusID " .
+         "WHERE s.StatusName != 'Gelöst' " .
+         "AND NOT EXISTS (SELECT 1 FROM TicketAssignees ta WHERE ta.TicketID = t.TicketID)";
+$tickets = query_db($query);
+
+$overdue = [];
+foreach ($tickets as $t) {
+    $priority = (int)$t['PriorityID'];
+    $threshold = $UNASSIGNED_WARNING_HOURS[$priority] ?? null;
+    if (!$threshold) continue;
+    try {
+        $created = new DateTime($t['CreatedAt'], new DateTimeZone('Europe/Berlin'));
+        $age_hours = ($now->getTimestamp() - $created->getTimestamp()) / 3600;
+        if ($age_hours >= $threshold) {
+            $overdue[] = $t;
+        }
+    } catch (Exception $e) {}
+}
+
+if (empty($overdue)) {
+    exit;
+}
+
+$agents = load_agents();
+$status_map = get_availability_status_map();
+$available_id = $status_map[1]['StatusID'] ?? 1;
+
+foreach ($agents as $ag) {
+    $avail = get_availability_for_agent($ag['AgentID'], $today, $today);
+    $status_id = $avail[$today]['StatusID'] ?? $available_id;
+    if ($status_id != $available_id) continue;
+    $lines = [];
+    foreach ($overdue as $t) {
+        $lines[] = '#' . $t['TicketID'] . ' (' . $t['PriorityName'] . ') ' . $t['Title'];
+    }
+    $body = "Folgende Tickets sind unzugewiesen:\n\n" . implode("\n", $lines) . "\n";
+    @mail($ag['AgentEmail'], 'Unzugewiesene Tickets', $body, "From: $HELPDESK_FROM");
+}


### PR DESCRIPTION
## Summary
- add cron job script to mail agents about unassigned tickets
- document cron setup in README

## Testing
- `php -l php/cron/notify_unassigned.php`


------
https://chatgpt.com/codex/tasks/task_e_68afe67d4e548327b6342137a7bebe30