### PR TITLE
Implement server push notifications

### DIFF
--- a/php/config.php
+++ b/php/config.php
@@ -41,4 +41,9 @@ $REACTION_TIME_HOURS = [
     2 => 4, // Mittel
     1 => 8  // Niedrig
 ];
+
+// Web Push VAPID configuration
+$PUSH_VAPID_PUBLIC_KEY = 'YOUR_PUBLIC_KEY';
+$PUSH_VAPID_PRIVATE_KEY = 'YOUR_PRIVATE_KEY';
+$PUSH_VAPID_SUBJECT = 'mailto:admin@example.com';
 ?>

--- a/php/cron/notify_unassigned.php
+++ b/php/cron/notify_unassigned.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../models.php';
+require_once __DIR__ . '/../push.php';
 
 $now = new DateTime('now', new DateTimeZone('Europe/Berlin'));
 $today = $now->format('Y-m-d');
@@ -45,4 +46,5 @@ foreach ($agents as $ag) {
     }
     $body = "Folgende Tickets sind unzugewiesen:\n\n" . implode("\n", $lines) . "\n";
     @mail($ag['AgentEmail'], 'Unzugewiesene Tickets', $body, "From: $HELPDESK_FROM");
+    send_push_notification([$ag['AgentID']], 'Unzugewiesene Tickets', $body);
 }

--- a/php/index.php
+++ b/php/index.php
@@ -153,6 +153,8 @@ if ($action === 'new_ticket') {
                     'CreatedAt' => $created_at
                 ];
                 send_assignment_email($info['AgentEmail'], $info['AgentName'], $ticket_info);
+                require_once __DIR__ . '/push.php';
+                send_push_notification([$assigned_agent], 'Ticket #' . $ticket_id . ' zugewiesen', $title);
             }
         }
         if (!empty($_FILES['attachment']['name']) && allowed_file($_FILES['attachment']['name'])) {
@@ -232,6 +234,8 @@ if ($action === 'update_ticket') {
                         'CreatedAt' => $ticket['CreatedAt']
                     ];
                     send_assignment_email($info['AgentEmail'], $info['AgentName'], $ticket_info);
+                    require_once __DIR__ . '/push.php';
+                    send_push_notification([$assign_agent], 'Ticket #' . $ticket_id . ' zugewiesen', $ticket['Title']);
                 }
             }
 

--- a/php/push.php
+++ b/php/push.php
@@ -1,0 +1,54 @@
+<?php
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/models.php';
+
+function send_push_notification($agent_ids, $title, $body) {
+    global $PUSH_VAPID_PUBLIC_KEY, $PUSH_VAPID_PRIVATE_KEY, $PUSH_VAPID_SUBJECT;
+
+    if (!class_exists('Minishlink\\WebPush\\WebPush')) {
+        return;
+    }
+
+    $auth = [
+        'VAPID' => [
+            'subject' => $PUSH_VAPID_SUBJECT,
+            'publicKey' => $PUSH_VAPID_PUBLIC_KEY,
+            'privateKey' => $PUSH_VAPID_PRIVATE_KEY,
+        ],
+    ];
+
+    $webPush = new Minishlink\WebPush\WebPush($auth);
+
+    $query = 'SELECT AgentID, Endpoint, P256dh, Auth FROM AgentPushSubscriptions';
+    $params = [];
+    if (!empty($agent_ids)) {
+        $placeholders = implode(',', array_fill(0, count($agent_ids), '?'));
+        $query .= " WHERE AgentID IN ($placeholders)";
+        $params = $agent_ids;
+    }
+    try {
+        $subs = query_db($query, $params);
+    } catch (Exception $e) {
+        return;
+    }
+    if (!$subs) return;
+
+    $payload = json_encode(['title' => $title, 'body' => $body]);
+
+    foreach ($subs as $sub) {
+        $subscription = Minishlink\WebPush\Subscription::create([
+            'endpoint' => $sub['Endpoint'],
+            'publicKey' => $sub['P256dh'],
+            'authToken' => $sub['Auth'],
+        ]);
+        $webPush->queueNotification($subscription, $payload);
+    }
+
+    $webPush->flush();
+}
+
+if (php_sapi_name() !== 'cli' && isset($_REQUEST['title']) && isset($_REQUEST['body'])) {
+    $agent = isset($_REQUEST['agent']) ? intval($_REQUEST['agent']) : null;
+    send_push_notification($agent ? [$agent] : [], $_REQUEST['title'], $_REQUEST['body']);
+}
+

--- a/php/static/js/service-worker.js
+++ b/php/static/js/service-worker.js
@@ -5,5 +5,6 @@ self.addEventListener('push', function(event) {
         body: data.body || '',
         icon: '../img/ifak-ticket-logo.svg'
     };
-    event.waitUntil(self.registration.showNotification(title, options));
+    const registration = self.registration;
+    event.waitUntil(registration.showNotification(title, options));
 });


### PR DESCRIPTION
## Summary
- support push events in service worker using registration.showNotification
- add PHP endpoint to dispatch push messages to agent subscriptions
- trigger push notifications on ticket assignment and overdue checks

## Testing
- `php -l php/push.php`
- `php -l php/index.php`
- `php -l php/cron/notify_unassigned.php`
- `php -l php/config.php`


------
https://chatgpt.com/codex/tasks/task_e_68afeda6529c832780e8a2aae2688ced