### PR TITLE
Add trainee-specific school availability status and reorder cycling

### DIFF
--- a/php/config.php
+++ b/php/config.php
@@ -24,7 +24,8 @@ $UNASSIGNED_WARNING_HOURS = [
 ];
 
 // ID des Auszubildenden für spezielle Verfügbarkeitsoptionen
-$TRAINEE_AGENT_ID = 5;
+// Der Auszubildende nutzt zusätzliche Verfügbarkeitsoptionen (z. B. Schule)
+$TRAINEE_AGENT_ID = 2;
 
 // Absenderadresse für Benachrichtigungen
 $HELPDESK_FROM = 'helpdesk@ifak-bochum.de';

--- a/php/templates/availability_edit.php
+++ b/php/templates/availability_edit.php
@@ -2,6 +2,10 @@
 $title = 'Meine Verfügbarkeit - IFAK Ticketsystem';
 include 'templates/header.php';
 $month_names = ['Januar','Februar','März','April','Mai','Juni','Juli','August','September','Oktober','November','Dezember'];
+// Nur der Auszubildende darf den Status "Schule" nutzen
+if ($agent['AgentID'] !== $TRAINEE_AGENT_ID) {
+    $statuses = array_filter($statuses, fn($s) => $s['StatusID'] != 4);
+}
 ?>
 <h1>Meine Verfügbarkeit</h1>
 <form method="POST" action="index.php?action=edit_availability">

--- a/php/templates/availability_overview.php
+++ b/php/templates/availability_overview.php
@@ -65,6 +65,10 @@ $month_names = ['Januar','Februar','März','April','Mai','Juni','Juli','August',
 const statusMap = <?php echo json_encode($status_map); ?>;
 const traineeId = <?php echo json_encode($TRAINEE_AGENT_ID); ?>;
 const currentAgent = <?php echo json_encode($agent['AgentID']); ?>;
+const codeMap = {};
+Object.values(statusMap).forEach(function(st){
+    codeMap[st.ShortCode] = st.StatusID;
+});
 document.querySelectorAll('.availability-day').forEach(function(td){
     if(td.classList.contains('weekend')) return;
     if(parseInt(td.dataset.agent) !== currentAgent) return;
@@ -72,12 +76,21 @@ document.querySelectorAll('.availability-day').forEach(function(td){
         let current = parseInt(td.dataset.status);
         const agentId = parseInt(td.dataset.agent);
         let next;
-        if(!current || current === statusMap[1].StatusID){
-            next = statusMap[2].StatusID;
-        } else if(current === statusMap[2].StatusID){
-            next = (agentId === traineeId) ? statusMap[4].StatusID : statusMap[3].StatusID;
+        if(!current){
+            // Erste Auswahl: Verfügbar
+            next = codeMap['V'];
+        } else if(current === codeMap['V']){
+            // Von Verfügbar zu Urlaub bzw. Schule (nur Azubi)
+            next = (agentId === traineeId && codeMap['S']) ? codeMap['S'] : codeMap['U'];
+        } else if(agentId === traineeId && codeMap['S'] && current === codeMap['S']){
+            // Von Schule zu Urlaub
+            next = codeMap['U'];
+        } else if(current === codeMap['U']){
+            // Von Urlaub zu Krank
+            next = codeMap['K'];
         } else {
-            next = statusMap[1].StatusID;
+            // Zurück zu Verfügbar
+            next = codeMap['V'];
         }
         td.dataset.status = next;
         td.style.backgroundColor = statusMap[next].ColorCode;


### PR DESCRIPTION
## Summary
- Start availability cycling with "Verfügbar" and add trainee-only "Schule" option
- Hide "Schule" status for non-trainees in availability editor
- Configure trainee ID for extra status options

## Testing
- `php -l php/config.php`
- `php -l php/templates/availability_overview.php`
- `php -l php/templates/availability_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68aff0bdcff88327a4ba69fecc3e3793