### PR TITLE
Enforce first ticket update to start work

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -190,6 +190,11 @@ if ($action === 'update_ticket') {
             $update_text = trim($_POST['update_text'] ?? '');
             $is_solution = isset($_POST['is_solution']) ? 1 : 0;
 
+            if ($ticket['StatusName'] == 'Neu' && !$status_id && ($update_text !== '' || $priority_id !== '' || $assign_agent !== '' || !empty($_FILES['attachment']['name']))) {
+                $in_progress = query_db("SELECT StatusID FROM TicketStatus WHERE StatusName = 'In Arbeit'", [], true);
+                if ($in_progress) { $status_id = $in_progress['StatusID']; }
+            }
+
             if ($is_solution) {
                 $solved = query_db("SELECT StatusID FROM TicketStatus WHERE StatusName = 'Gelöst'", [], true);
                 if ($solved) { $status_id = $solved['StatusID']; }

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -162,10 +162,12 @@
                     <div class="form-row">
                         <div class="form-group">
                             <label for="status_id">Status ändern:</label>
-                            <select id="status_id" name="status_id">
+                            <select id="status_id" name="status_id" <?php if ($ticket['StatusName'] == 'Neu') echo 'required'; ?>>
+                                <?php if ($ticket['StatusName'] != 'Neu'): ?>
                                 <option value="">-- Unverändert --</option>
+                                <?php endif; ?>
                                 <?php foreach ($statuses as $s): if ($s['StatusName'] != 'Neu' && $s['StatusName'] != 'Gelöst'): ?>
-                                <option value="<?php echo $s['StatusID']; ?>" <?php if ($s['StatusID'] == $ticket['StatusID']) echo 'selected'; ?>><?php echo htmlspecialchars($s['StatusName']); ?></option>
+                                <option value="<?php echo $s['StatusID']; ?>" <?php if (($ticket['StatusName'] == 'Neu' && $s['StatusName'] == 'In Arbeit') || ($s['StatusID'] == $ticket['StatusID'])) echo 'selected'; ?>><?php echo htmlspecialchars($s['StatusName']); ?></option>
                                 <?php endif; endforeach; ?>
                             </select>
                         </div>


### PR DESCRIPTION
## Summary
- Automatically set status to "In Arbeit" when a new ticket receives updates without an explicit status change.
- Require a status choice for tickets in "Neu" and default the dropdown to "In Arbeit" on the ticket view page.

## Testing
- `php -l php/index.php`
- `php -l php/templates/ticket_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b09aced7b4832793202ee233ca4af3