### PR TITLE
Refine availability status handling

### DIFF
--- a/php/templates/availability_edit.php
+++ b/php/templates/availability_edit.php
@@ -4,11 +4,13 @@ include 'templates/header.php';
 $month_names = ['Januar','Februar','März','April','Mai','Juni','Juli','August','September','Oktober','November','Dezember'];
 // Nur der Auszubildende darf den Status "Schule" nutzen
 if ($agent['AgentID'] !== $TRAINEE_AGENT_ID) {
-    $statuses = array_filter($statuses, fn($s) => $s['StatusID'] != 4);
+    $statuses = array_filter($statuses, fn($s) => $s['ShortCode'] !== 'S');
 }
 if (!in_array($agent['AgentID'], $PART_TIME_AGENT_IDS)) {
     $statuses = array_filter($statuses, fn($s) => $s['ShortCode'] !== 'F');
 }
+$statuses = array_values($statuses);
+$default_status_id = $statuses[0]['StatusID'] ?? null;
 ?>
 <h1>Meine Verfügbarkeit</h1>
 <form method="POST" action="index.php?action=edit_availability">
@@ -24,7 +26,7 @@ if (!in_array($agent['AgentID'], $PART_TIME_AGENT_IDS)) {
             <tr>
             <?php for ($d=1; $d <= (int)$month_end->format('j'); $d++): ?>
                 <?php $date = $month_start->format('Y-m-') . sprintf('%02d',$d);
-                      $current = $availability[$date]['StatusID'] ?? 1; ?>
+                      $current = $availability[$date]['StatusID'] ?? $default_status_id; ?>
                 <td>
                     <select name="status[<?php echo $date; ?>]">
                         <?php foreach ($statuses as $s): ?>

--- a/php/templates/availability_overview.php
+++ b/php/templates/availability_overview.php
@@ -66,50 +66,30 @@ const statusMap = <?php echo json_encode($status_map); ?>;
 const traineeId = <?php echo json_encode($TRAINEE_AGENT_ID); ?>;
 const currentAgent = <?php echo json_encode($agent['AgentID']); ?>;
 const partTimeIds = <?php echo json_encode($PART_TIME_AGENT_IDS); ?>;
-const codeMap = {};
-Object.values(statusMap).forEach(function(st){
-    codeMap[st.ShortCode] = st.StatusID;
-});
+const statusSequence = Object.values(statusMap).sort((a,b)=>a.StatusID-b.StatusID);
 document.querySelectorAll('.availability-day').forEach(function(td){
     if(td.classList.contains('weekend')) return;
-    if(parseInt(td.dataset.agent) !== currentAgent) return;
+    if(currentAgent !== 1 && parseInt(td.dataset.agent) !== currentAgent) return;
     td.addEventListener('click', function(){
-        let current = parseInt(td.dataset.status);
         const agentId = parseInt(td.dataset.agent);
-        let next;
-        if(!current){
-            // Erste Auswahl: Verfügbar
-            next = codeMap['V'];
-        } else if(current === codeMap['V']){
-            if(partTimeIds.includes(agentId) && codeMap['F']){
-                // Von Verfügbar zu Frei (nur Teilzeit)
-                next = codeMap['F'];
-            } else if(agentId === traineeId && codeMap['S']){
-                // Von Verfügbar zu Schule (nur Azubi)
-                next = codeMap['S'];
-            } else {
-                // Von Verfügbar zu Urlaub
-                next = codeMap['U'];
-            }
-        } else if(partTimeIds.includes(agentId) && codeMap['F'] && current === codeMap['F']){
-            // Von Frei zu Urlaub
-            next = codeMap['U'];
-        } else if(agentId === traineeId && codeMap['S'] && current === codeMap['S']){
-            // Von Schule zu Urlaub
-            next = codeMap['U'];
-        } else if(current === codeMap['U']){
-            // Von Urlaub zu Krank
-            next = codeMap['K'];
-        } else {
-            // Zurück zu Verfügbar
-            next = codeMap['V'];
+        let sequence = statusSequence;
+        if(currentAgent !== 1){
+            sequence = sequence.filter(st => {
+                if(st.ShortCode === 'S' && agentId !== traineeId) return false;
+                if(st.ShortCode === 'F' && !partTimeIds.includes(agentId)) return false;
+                return true;
+            });
         }
-        td.dataset.status = next;
-        td.style.backgroundColor = statusMap[next].ColorCode;
+        const current = parseInt(td.dataset.status);
+        const idx = sequence.findIndex(s => s.StatusID === current);
+        const nextStatus = sequence[(idx + 1) % sequence.length];
+        td.dataset.status = nextStatus.StatusID;
+        td.style.backgroundColor = nextStatus.ColorCode;
+        td.title = nextStatus.ShortCode;
         fetch('index.php?action=set_availability', {
             method:'POST',
             headers:{'Content-Type':'application/x-www-form-urlencoded'},
-            body:'date=' + encodeURIComponent(td.dataset.date) + '&status_id=' + next
+            body:'date=' + encodeURIComponent(td.dataset.date) + '&status_id=' + nextStatus.StatusID
         });
     });
 });


### PR DESCRIPTION
## Summary
- Cycle availability statuses using a sorted sequence
- Filter status options per agent, with master override
- Use first status as default in manual edit form

## Testing
- `php -l php/templates/availability_overview.php`
- `php -l php/templates/availability_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68b43a0c9a788327bbc0d284aae9f7a6