### PR TITLE
Allow viewing and downloading Markdown attachments

### DIFF
--- a/php/config.php
+++ b/php/config.php
@@ -8,7 +8,7 @@ $DATABASE = [
 ];
 
 $UPLOAD_FOLDER = $BASE_DIR . '/static/uploads';
-$ALLOWED_EXTENSIONS = ['png','jpg','jpeg','gif','pdf','doc','docx','txt','zip'];
+$ALLOWED_EXTENSIONS = ['png','jpg','jpeg','gif','pdf','doc','docx','txt','zip','md'];
 $MAX_CONTENT_LENGTH = 10 * 1024 * 1024; // 10MB
 
 $SECRET_KEY = 'your-secret-key-here'; // TODO: change in production

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -132,4 +132,20 @@ function send_solution_email($ticket, $updates) {
         @mail($submitter, $subject, $body, "From: $HELPDESK_FROM");
     }
 }
+
+function markdown_to_html($text) {
+    $text = htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+    $patterns = [
+        '/^### (.+)$/m' => '<h3>$1</h3>',
+        '/^## (.+)$/m' => '<h2>$1</h2>',
+        '/^# (.+)$/m' => '<h1>$1</h1>',
+        '/\*\*(.+?)\*\*/s' => '<strong>$1</strong>',
+        '/\*(.+?)\*/s' => '<em>$1</em>',
+        '/`(.+?)`/s' => '<code>$1</code>'
+    ];
+    foreach ($patterns as $regex => $replacement) {
+        $text = preg_replace($regex, $replacement, $text);
+    }
+    return nl2br($text);
+}
 ?>

--- a/php/index.php
+++ b/php/index.php
@@ -322,6 +322,22 @@ if ($action === 'view_ticket') {
     exit;
 }
 
+if ($action === 'view_markdown') {
+    $file = $_GET['file'] ?? '';
+    $safe = preg_match('/^[\w.\-]+$/', $file);
+    $path = __DIR__ . '/static/uploads/' . $file;
+    if (!$safe || !is_file($path)) {
+        http_response_code(404);
+        echo 'Datei nicht gefunden';
+        exit;
+    }
+    $content = file_get_contents($path);
+    $markdown_html = markdown_to_html($content);
+    $markdown_file = $file;
+    include 'templates/markdown_view.php';
+    exit;
+}
+
 // default dashboard with filters
 $team_filter = $_GET['team'] ?? 'mine';
 $status_filter = $_GET['status'] ?? 'open';

--- a/php/static/css/style.css
+++ b/php/static/css/style.css
@@ -32,6 +32,16 @@ body {
     flex-direction: column;
 }
 
+/* Markdown view */
+.markdown-view {
+    padding: 20px;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: var(--shadow);
+    max-width: 800px;
+    margin: 20px auto;
+}
+
 /* ==============================================
    HEADER & NAVIGATION
    ============================================== */

--- a/php/templates/markdown_view.php
+++ b/php/templates/markdown_view.php
@@ -1,0 +1,5 @@
+<?php $title = $markdown_file; include 'templates/header.php'; ?>
+<div class="markdown-view">
+    <?php echo $markdown_html; ?>
+</div>
+<?php include 'templates/footer.php'; ?>

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -120,12 +120,19 @@
                             📄
                         <?php elseif (in_array($ext, ['doc','docx'])): ?>
                             📝
+                        <?php elseif ($ext == 'md'): ?>
+                            📘
                         <?php else: ?>
                             📎
                         <?php endif; ?>
                     </div>
                     <div class="attachment-info">
-                        <a href="<?php echo $base_url; ?>/static/uploads/<?php echo $a['StoragePath']; ?>" target="_blank" class="attachment-name"><?php echo htmlspecialchars($a['FileName']); ?></a>
+                        <?php if ($ext == 'md'): ?>
+                            <a href="index.php?action=view_markdown&amp;file=<?php echo urlencode($a['StoragePath']); ?>" target="_blank" class="attachment-name"><?php echo htmlspecialchars($a['FileName']); ?></a>
+                            (<a href="<?php echo $base_url; ?>/static/uploads/<?php echo $a['StoragePath']; ?>" download>Download</a>)
+                        <?php else: ?>
+                            <a href="<?php echo $base_url; ?>/static/uploads/<?php echo $a['StoragePath']; ?>" target="_blank" class="attachment-name"><?php echo htmlspecialchars($a['FileName']); ?></a>
+                        <?php endif; ?>
                         <div class="attachment-meta"><?php echo $a['FormattedUploadedAt']; ?> • <?php echo round($a['FileSize']/1024,1); ?> KB</div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- enable uploads of `.md` files by extending allowed extensions
- render Markdown attachments through new `view_markdown` action and template
- show view and download links for Markdown attachments and style markdown page

## Testing
- `php -l php/config.php`
- `php -l php/helpers.php`
- `php -l php/index.php`
- `php -l php/templates/ticket_view.php`
- `php -l php/templates/markdown_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b443a55a308327a5ca3e114b4e42a5