### PR TITLE
feat: markdown modal and ticket navigation

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -333,6 +333,10 @@ if ($action === 'view_markdown') {
     }
     $content = file_get_contents($path);
     $markdown_html = markdown_to_html($content);
+    if (isset($_GET['raw']) && $_GET['raw'] === '1') {
+        echo '<div class="markdown-view">' . $markdown_html . '</div>';
+        exit;
+    }
     $markdown_file = $file;
     include 'templates/markdown_view.php';
     exit;

--- a/php/static/css/style.css
+++ b/php/static/css/style.css
@@ -433,6 +433,24 @@ button:hover {
     opacity: 0.9;
 }
 
+.ticket-nav {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 5px;
+}
+
+.ticket-nav-link {
+    text-decoration: none;
+    font-weight: bold;
+    padding: 2px 6px;
+}
+
+.ticket-nav-input {
+    width: 60px;
+    text-align: center;
+}
+
 .ticket-content {
     display: flex;
     min-height: 500px;
@@ -779,6 +797,37 @@ footer {
     top: 20px;
     right: 30px;
     color: white;
+    font-size: 2rem;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+/* Markdown modal */
+.md-modal {
+    display: none;
+    position: fixed;
+    z-index: 1001;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.8);
+    overflow: auto;
+}
+
+.md-modal-content {
+    background: #fff;
+    margin: 40px auto;
+    padding: 20px;
+    max-width: 800px;
+    border-radius: 4px;
+}
+
+.md-modal-close {
+    position: absolute;
+    top: 20px;
+    right: 30px;
+    color: #fff;
     font-size: 2rem;
     font-weight: bold;
     cursor: pointer;

--- a/php/static/js/main.js
+++ b/php/static/js/main.js
@@ -108,3 +108,42 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 });
+
+// Modal für Markdown-Anhänge
+document.addEventListener('DOMContentLoaded', function() {
+    const modal = document.createElement('div');
+    modal.id = 'md-modal';
+    modal.className = 'md-modal';
+
+    const closeBtn = document.createElement('span');
+    closeBtn.className = 'md-modal-close';
+    closeBtn.textContent = '\u00d7';
+
+    const content = document.createElement('div');
+    content.className = 'md-modal-content';
+
+    modal.appendChild(closeBtn);
+    modal.appendChild(content);
+    document.body.appendChild(modal);
+
+    document.addEventListener('click', function(e) {
+        if (e.target.matches('.md-attachment')) {
+            e.preventDefault();
+            const url = e.target.getAttribute('href') + '&raw=1';
+            fetch(url)
+                .then(function(resp) { return resp.text(); })
+                .then(function(html) {
+                    content.innerHTML = html;
+                    modal.style.display = 'block';
+                });
+        } else if (e.target === modal || e.target === closeBtn) {
+            modal.style.display = 'none';
+        }
+    });
+
+    document.addEventListener('keyup', function(e) {
+        if (e.key === 'Escape') {
+            modal.style.display = 'none';
+        }
+    });
+});

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -12,6 +12,15 @@
             </div>
             <span class="ticket-id">Ticket-ID: <?php echo $ticket['TicketID']; ?></span>
         </div>
+        <?php $prev_id = $ticket['TicketID'] - 1; $next_id = $ticket['TicketID'] + 1; ?>
+        <div class="ticket-nav">
+            <a href="index.php?action=view_ticket&amp;id=<?php echo $prev_id; ?>" class="ticket-nav-link">&lt;</a>
+            <form method="GET" action="index.php" class="ticket-nav-form">
+                <input type="hidden" name="action" value="view_ticket">
+                <input type="number" name="id" value="<?php echo $ticket['TicketID']; ?>" class="ticket-nav-input">
+            </form>
+            <a href="index.php?action=view_ticket&amp;id=<?php echo $next_id; ?>" class="ticket-nav-link">&gt;</a>
+        </div>
         <h1><?php echo htmlspecialchars($ticket['Title']); ?></h1>
     </div>
 
@@ -128,7 +137,7 @@
                     </div>
                     <div class="attachment-info">
                         <?php if ($ext == 'md'): ?>
-                            <a href="index.php?action=view_markdown&amp;file=<?php echo urlencode($a['StoragePath']); ?>" target="_blank" class="attachment-name"><?php echo htmlspecialchars($a['FileName']); ?></a>
+                            <a href="index.php?action=view_markdown&amp;file=<?php echo urlencode($a['StoragePath']); ?>" class="attachment-name md-attachment"><?php echo htmlspecialchars($a['FileName']); ?></a>
                             (<a href="<?php echo $base_url; ?>/static/uploads/<?php echo $a['StoragePath']; ?>" download>Download</a>)
                         <?php else: ?>
                             <a href="<?php echo $base_url; ?>/static/uploads/<?php echo $a['StoragePath']; ?>" target="_blank" class="attachment-name"><?php echo htmlspecialchars($a['FileName']); ?></a>


### PR DESCRIPTION
## Summary
- show markdown attachments in a modal overlay
- add prev/next jump and direct ID input to ticket view
- support raw markdown endpoint and related styles

## Testing
- `php -l php/index.php`
- `php -l php/templates/ticket_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b467ac30ec832785de1f2b11eca43e