### PR TITLE
Highlight delayed unassigned tickets

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ from config import (
     SECRET_KEY,
     DEBUG,
     OLD_TICKET_THRESHOLD_DAYS,
+    UNASSIGNED_WARNING_HOURS,
 )
 from database import (
     get_ticket_db,
@@ -204,6 +205,25 @@ def dashboard():
         agent_id=agent_filter,
         assigned_only=assigned_only,
     )
+
+    # Unzugewiesene Tickets nach Reaktionszeit markieren
+    now = datetime.now(ZoneInfo("Europe/Berlin"))
+    for t in tickets:
+        created_ts = t.get("CreatedAtTS")
+        if created_ts:
+            try:
+                created_dt = datetime.fromisoformat(created_ts)
+                age_hours = int((now - created_dt).total_seconds() / 3600)
+            except ValueError:
+                age_hours = 0
+        else:
+            age_hours = 0
+        t["AgeHours"] = age_hours
+        t["Delayed"] = False
+        if not t.get("AssignedAgents"):
+            threshold = UNASSIGNED_WARNING_HOURS.get(t.get("PriorityID"))
+            if threshold is not None and age_hours > threshold:
+                t["Delayed"] = True
 
     # Teams und Status für Filter laden
     teams = get_all_teams()

--- a/config.py
+++ b/config.py
@@ -36,3 +36,12 @@ PERMANENT_SESSION_LIFETIME = 30 * 24 * 60 * 60  # 30 Tage
 # Offene Tickets, die älter als dieser Schwellenwert sind, werden im Dashboard
 # farblich hervorgehoben.
 OLD_TICKET_THRESHOLD_DAYS = 30
+
+# Schwellenwerte in Stunden für unzugewiesene Tickets nach Priorität
+# Wird genutzt, um Tickets im Dashboard optisch hervorzuheben,
+# wenn sie länger als die definierte Zeit offen und unzugewiesen sind.
+UNASSIGNED_WARNING_HOURS = {
+    3: 1,  # Hoch
+    2: 4,  # Mittel
+    1: 8,  # Niedrig
+}

--- a/database.py
+++ b/database.py
@@ -195,7 +195,8 @@ def get_tickets_with_filters(
                s.StatusName, s.ColorCode as StatusColor,
                p.PriorityName, p.ColorCode as PriorityColor,
                team.TeamName, team.TeamColor,
-                strftime('%d.%m.%Y %H:%M', t.CreatedAt, 'localtime') as CreatedAt,
+               strftime('%d.%m.%Y %H:%M', t.CreatedAt, 'localtime') as CreatedAt,
+               t.CreatedAt as CreatedAtTS,
                CAST(julianday('now') - julianday(t.CreatedAt) AS INT) as AgeDays,
                GROUP_CONCAT(ta.AgentName, ', ') as AssignedAgents
         FROM Tickets t

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -90,7 +90,7 @@
             </thead>
             <tbody>
                 {% for ticket in tickets %}
-                <tr class="ticket-row {% if ticket.AgeDays > old_ticket_threshold and ticket.StatusName != 'Gelöst' %}old-ticket{% endif %}" onclick="window.location='{{ url_for('view_ticket', ticket_id=ticket.TicketID) }}'">
+                <tr class="ticket-row {% if ticket.AgeDays > old_ticket_threshold and ticket.StatusName != 'Gelöst' %}old-ticket{% endif %}{% if ticket.Delayed %} delayed-ticket{% endif %}" onclick="window.location='{{ url_for('view_ticket', ticket_id=ticket.TicketID) }}'">
                     <td>{{ ticket.TicketID }}</td>
                     <td>
                         <span class="team-badge" style="background-color: {{ ticket.TeamColor }}">
@@ -109,7 +109,15 @@
                     </td>
                     <td class="title-cell">{{ ticket.Title }}</td>
                     <td>{{ ticket.ContactName }}</td>
-                    <td>{{ ticket.AssignedAgents or "Nicht zugewiesen" }}</td>
+                    <td>
+                        {% if ticket.AssignedAgents %}
+                            {{ ticket.AssignedAgents }}
+                        {% else %}
+                            <span class="unassigned-badge{% if ticket.Delayed %} overdue{% endif %}">
+                                Offen: {% if ticket.AgeDays > 0 %}{{ ticket.AgeDays }}d{% else %}{{ ticket.AgeHours }}h{% endif %}
+                            </span>
+                        {% endif %}
+                    </td>
                     <td>{{ ticket.CreatedAt }}</td>
                     <td>{{ ticket.AgeDays }}</td>
                     <td>{{ ticket.CreatedByName }}</td>


### PR DESCRIPTION
## Summary
- flag unassigned tickets in the dashboard when they exceed priority-based time limits
- include creation timestamp in ticket query to calculate unassigned age
- add per-priority warning thresholds to configuration

## Testing
- `python -m py_compile app.py database.py addressbook.py config.py`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_68b472cc4e40832784f318b8d5b113de