### PR TITLE
Enable lightbox for images in markdown modal

### DIFF
--- a/php/static/css/style.css
+++ b/php/static/css/style.css
@@ -842,6 +842,14 @@ footer {
     border-radius: 4px;
 }
 
+.md-modal-content img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 10px 0;
+    cursor: pointer;
+}
+
 .md-modal-close {
     position: absolute;
     top: 20px;

--- a/php/static/js/main.js
+++ b/php/static/js/main.js
@@ -93,7 +93,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     document.addEventListener('click', function(e) {
-        if (e.target.matches('.attachment-preview img')) {
+        if (e.target.matches('.attachment-preview img, .md-modal-content img')) {
             e.preventDefault();
             img.src = e.target.src;
             lightbox.style.display = 'block';
@@ -134,6 +134,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 .then(function(resp) { return resp.text(); })
                 .then(function(html) {
                     content.innerHTML = html;
+                    content.querySelectorAll('img').forEach(function(imgEl) {
+                        imgEl.setAttribute('title', 'Klick zum Vergrößern');
+                    });
                     modal.style.display = 'block';
                 });
         } else if (e.target === modal || e.target === closeBtn) {


### PR DESCRIPTION
## Summary
- Allow existing lightbox to handle images embedded in markdown attachments
- Style markdown modal images to fit and indicate click to zoom

## Testing
- `php -l php/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b477228b988327a55c5556aa711ec1