### PR TITLE
feat: preview markdown attachments in modal

### DIFF
--- a/php/static/css/style.css
+++ b/php/static/css/style.css
@@ -682,6 +682,16 @@ button:hover {
     font-weight: bold;
 }
 
+.attachment-preview a {
+    color: inherit;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+}
+
 .attachment-preview::after {
     content: '\1F50D'; /* magnifying glass */
     position: absolute;

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -130,18 +130,13 @@
                         <?php elseif (in_array($ext, ['doc','docx'])): ?>
                             📝
                         <?php elseif ($ext == 'md'): ?>
-                            📘
+                            <a href="index.php?action=view_markdown&amp;file=<?php echo urlencode($a['StoragePath']); ?>" class="md-attachment">📘</a>
                         <?php else: ?>
                             📎
                         <?php endif; ?>
                     </div>
                     <div class="attachment-info">
-                        <?php if ($ext == 'md'): ?>
-                            <a href="index.php?action=view_markdown&amp;file=<?php echo urlencode($a['StoragePath']); ?>" class="attachment-name md-attachment"><?php echo htmlspecialchars($a['FileName']); ?></a>
-                            (<a href="<?php echo $base_url; ?>/static/uploads/<?php echo $a['StoragePath']; ?>" download>Download</a>)
-                        <?php else: ?>
-                            <a href="<?php echo $base_url; ?>/static/uploads/<?php echo $a['StoragePath']; ?>" target="_blank" class="attachment-name"><?php echo htmlspecialchars($a['FileName']); ?></a>
-                        <?php endif; ?>
+                        <a href="<?php echo $base_url; ?>/static/uploads/<?php echo $a['StoragePath']; ?>" target="_blank" class="attachment-name"><?php echo htmlspecialchars($a['FileName']); ?></a>
                         <div class="attachment-meta"><?php echo $a['FormattedUploadedAt']; ?> • <?php echo round($a['FileSize']/1024,1); ?> KB</div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- allow markdown attachments to open in modal via preview icon
- simplify attachment markup and remove redundant download link
- style attachment preview anchors for consistent appearance

## Testing
- `php -l templates/ticket_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b47a0673f48327af37ecfa0220b29d