### PR TITLE
feat: add solved ticket counts

### DIFF
--- a/php/models.php
+++ b/php/models.php
@@ -24,12 +24,14 @@ function get_agent_by_token($token) {
 
 function get_agents_with_ticket_counts() {
     $query = "SELECT a.AgentID, a.AgentName, a.TeamID, t.TeamName, " .
-             "COUNT(CASE WHEN s.StatusName != 'Gelöst' THEN 1 END) AS OpenTickets " .
+             "COUNT(DISTINCT CASE WHEN s.StatusName != 'Gelöst' THEN tk.TicketID END) AS OpenTickets, " .
+             "COUNT(CASE WHEN tu.IsSolution = 1 AND tu.UpdatedByName = a.AgentName THEN 1 END) AS SolvedTickets " .
              "FROM Agents a " .
              "JOIN Teams t ON a.TeamID = t.TeamID " .
              "LEFT JOIN TicketAssignees ta ON a.AgentID = ta.AgentID " .
              "LEFT JOIN Tickets tk ON tk.TicketID = ta.TicketID " .
              "LEFT JOIN TicketStatus s ON tk.StatusID = s.StatusID " .
+             "LEFT JOIN TicketUpdates tu ON tk.TicketID = tu.TicketID " .
              "WHERE a.Active = 1 " .
              "GROUP BY a.AgentID ORDER BY a.AgentName";
     return query_db($query);

--- a/php/templates/header.php
+++ b/php/templates/header.php
@@ -34,7 +34,7 @@ if (!isset($status_map)) $status_map = get_availability_status_map();
                 </div>
                 <a href="index.php?agent=<?php echo $ov['AgentID']; ?>" class="agent-link">
                     <?php echo htmlspecialchars($ov['AgentName']); ?>
-                    (<?php echo $ov['OpenTickets']; ?>)
+                    (<?php echo $ov['OpenTickets']; ?> | <?php echo $ov['SolvedTickets']; ?>)
                 </a>
                 <div class="week-boxes">
                     <?php foreach ($week2_dates as $d): ?>


### PR DESCRIPTION
## Summary
- track solved ticket count per agent in get_agents_with_ticket_counts
- show open and solved ticket counts in header overview

## Testing
- `php -l php/models.php`
- `php -l php/templates/header.php`
- `php -l php/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b47f51113c83279f59d31f0d481b0c