### PR TITLE
Show ticket age and last update in ticket view

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -274,6 +274,7 @@ if ($action === 'view_ticket') {
     $ticket = get_ticket_by_id($ticket_id);
     $attachments = get_ticket_attachments($ticket_id);
     $updates = get_ticket_updates($ticket_id);
+    $last_update_at = $updates ? $updates[0]['FormattedUpdatedAt'] : $ticket['CreatedAt'];
     $assignees = get_ticket_assignees($ticket_id);
     $related_person = [];
     $related_facility = [];

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -9,6 +9,8 @@
                 <span>Erstellt am: <?php echo $ticket['CreatedAt']; ?></span>
                 <span>von <?php echo htmlspecialchars($ticket['CreatedByName']); ?></span>
                 <?php if ($ticket['Source']): ?><span>via <?php echo htmlspecialchars($ticket['Source']); ?></span><?php endif; ?>
+                <span>Offen seit: <?php echo $ticket['AgeDays']; ?> Tage</span>
+                <span>Letzte Aktualisierung: <?php echo $last_update_at; ?></span>
             </div>
             <span class="ticket-id">Ticket-ID: <?php echo $ticket['TicketID']; ?></span>
         </div>


### PR DESCRIPTION
## Summary
- Track last update time for tickets when loading
- Display ticket age in days and last update timestamp in meta section

## Testing
- `php -l php/index.php`
- `php -l php/templates/ticket_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b47f61a86083278658c0fefe687018