### PR TITLE
Use contact email for solution notifications

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -116,6 +116,7 @@ function send_assignment_email($agent_email, $agent_name, $ticket) {
 }
 
 function send_solution_email($ticket, $updates) {
+    if (empty($ticket['ContactEmail'])) return;
     global $QUALITY_CONTROL_EMAIL, $HELPDESK_FROM;
     $base_url = get_base_url();
     $link = $base_url . '/index.php?action=view_ticket&id=' . $ticket['TicketID'];
@@ -134,11 +135,8 @@ function send_solution_email($ticket, $updates) {
     if (!empty($QUALITY_CONTROL_EMAIL)) {
         @mail($QUALITY_CONTROL_EMAIL, $subject, $body, "From: $HELPDESK_FROM");
     }
-    $submitter = 'helpdesk@ifak-sozial.de'; // Platzhalter für die aufgebende Person
-    // $submitter = $ticket['ContactEmail'];
-    if ($submitter) {
-        @mail($submitter, $subject, $body, "From: $HELPDESK_FROM");
-    }
+    $submitter = $ticket['ContactEmail'];
+    @mail($submitter, $subject, $body, "From: $HELPDESK_FROM");
 }
 
 function markdown_to_html($text) {


### PR DESCRIPTION
## Summary
- Return early from `send_solution_email` when tickets lack a contact email
- Send solution notifications to the ticket's contact email instead of a placeholder address

## Testing
- `php -l php/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68b482a29ec48327b11599c66782ffee