### PR TITLE
Verhindere Hervorhebung gelöster Tickets als offen

### DIFF
--- a/php/templates/dashboard.php
+++ b/php/templates/dashboard.php
@@ -84,6 +84,8 @@ if (!isset($current_agent_filter)) $current_agent_filter = '';
                     <td>
                         <?php if (!empty($ticket['AssignedAgents'])): ?>
                             <?php echo htmlspecialchars($ticket['AssignedAgents']); ?>
+                        <?php elseif ($ticket['StatusName'] === 'Gelöst'): ?>
+                            &ndash;
                         <?php else: ?>
                             <span class="unassigned-badge<?php if (!empty($ticket['Delayed'])) echo ' overdue'; ?>">Offen: <?php echo $ticket['AgeDays'] > 0 ? $ticket['AgeDays'] . 'd' : $ticket['AgeHours'] . 'h'; ?></span>
                         <?php endif; ?>


### PR DESCRIPTION
## Summary
- Zeige gelöste, nicht zugewiesene Tickets in der Übersicht ohne "Offen"-Hinweis

## Testing
- `php -l php/templates/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4913d8f6c832787f2f57618778290