### PR TITLE
Align ticket form and view dropdown layouts

### DIFF
--- a/php/templates/ticket_form.php
+++ b/php/templates/ticket_form.php
@@ -2,11 +2,11 @@
 <div class="ticket-form">
     <h1>Neues Ticket erstellen</h1>
     <form method="POST" enctype="multipart/form-data" action="index.php?action=new_ticket">
+        <div class="form-group">
+            <label for="title">Titel*:</label>
+            <input type="text" name="title" id="title" required placeholder="Kurze Beschreibung des Problems">
+        </div>
         <div class="form-row">
-            <div class="form-group">
-                <label for="title">Titel*:</label>
-                <input type="text" name="title" id="title" required placeholder="Kurze Beschreibung des Problems">
-            </div>
             <div class="form-group">
                 <label for="priority_id">Priorität*:</label>
                 <select name="priority_id" id="priority_id" required>
@@ -15,8 +15,6 @@
                     <?php endforeach; ?>
                 </select>
             </div>
-        </div>
-        <div class="form-row">
             <div class="form-group">
                 <label for="team_id">Team*:</label>
                 <select name="team_id" id="team_id" required>

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -193,20 +193,20 @@
                                 <?php endforeach; ?>
                             </select>
                         </div>
-                    </div>
-                    <div class="form-group">
-                        <label for="assign_agent">Agent zuweisen:</label>
-                        <?php $current_assignee_id = $assignees[0]['AgentID'] ?? null; ?>
-                        <select id="assign_agent" name="assign_agent">
-                            <option value="">-- Niemanden zuweisen --</option>
-                            <?php foreach ($agents as $ag):
-                                if ($ag['AgentID'] == $current_assignee_id) { continue; }
-                                $label = ($ag['AgentID'] == $agent['AgentID']) ? 'Mich selbst' : $ag['AgentName'];
-                                $label .= ' (' . $ag['TeamName'] . ')';
-                            ?>
-                            <option value="<?php echo $ag['AgentID']; ?>"><?php echo htmlspecialchars($label); ?></option>
-                            <?php endforeach; ?>
-                        </select>
+                        <div class="form-group">
+                            <label for="assign_agent">Agent zuweisen:</label>
+                            <?php $current_assignee_id = $assignees[0]['AgentID'] ?? null; ?>
+                            <select id="assign_agent" name="assign_agent">
+                                <option value="">-- Niemanden zuweisen --</option>
+                                <?php foreach ($agents as $ag):
+                                    if ($ag['AgentID'] == $current_assignee_id) { continue; }
+                                    $label = ($ag['AgentID'] == $agent['AgentID']) ? 'Mich selbst' : $ag['AgentName'];
+                                    $label .= ' (' . $ag['TeamName'] . ')';
+                                ?>
+                                <option value="<?php echo $ag['AgentID']; ?>"><?php echo htmlspecialchars($label); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
                     </div>
                     <div class="form-group">
                         <label for="update_text">Kommentar:</label>


### PR DESCRIPTION
## Summary
- Place status, priority, and agent selectors in a single row on the ticket view
- Arrange priority, team, and assignment fields in one row on new ticket form while giving title full width

## Testing
- `php -l php/templates/ticket_view.php`
- `php -l php/templates/ticket_form.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4970a11888327a7a0f0245040205c