### PR TITLE
Extend ticket search with person and facility filters

### DIFF
--- a/php/api/search_tickets.php
+++ b/php/api/search_tickets.php
@@ -4,9 +4,11 @@ require_once __DIR__ . '/../models.php';
 
 header('Content-Type: application/json');
 $term = $_GET['term'] ?? '';
-if (strlen($term) < 2) {
+$person = $_GET['person'] ?? null;
+$facility = $_GET['facility'] ?? null;
+if (strlen($term) < 2 && !$person && !$facility) {
     echo json_encode([]);
     exit;
 }
-$results = search_tickets($term);
+$results = search_tickets($term, $person, $facility);
 echo json_encode($results);

--- a/php/index.php
+++ b/php/index.php
@@ -351,6 +351,8 @@ if ($action === 'view_markdown') {
 $team_filter = $_GET['team'] ?? 'mine';
 $status_filter = $_GET['status'] ?? 'open';
 $search_value = trim($_GET['q'] ?? '');
+$person_value = trim($_GET['person'] ?? '');
+$facility_value = trim($_GET['facility'] ?? '');
 $agent_filter_param = $_GET['agent'] ?? null;
 
 $team_id = null;
@@ -375,7 +377,7 @@ if ($agent_filter_param) {
     $assigned_only = true;
 }
 
-$tickets = get_tickets_with_filters($team_id, $status_filter, $search_value ?: null, $filter_agent, $assigned_only, $include_global_new, $agent['TeamID']);
+$tickets = get_tickets_with_filters($team_id, $status_filter, $search_value ?: null, $filter_agent, $assigned_only, $include_global_new, $agent['TeamID'], $person_value ?: null, $facility_value ?: null);
 
 // mark unassigned new tickets that exceed configured thresholds and stale tickets
 foreach ($tickets as &$t) {
@@ -401,4 +403,6 @@ $current_team_filter = $team_filter;
 $current_status_filter = $status_filter;
 $current_agent_filter = $agent_filter_param;
 $search_term = $search_value;
+$person_term = $person_value;
+$facility_term = $facility_value;
 include 'templates/dashboard.php';

--- a/php/models.php
+++ b/php/models.php
@@ -43,8 +43,8 @@ function get_agents_with_ticket_counts() {
     return query_db($query);
 }
 
-function get_tickets_with_filters($team_id = null, $status_filter = 'open', $search_term = null, $agent_id = null, $assigned_only = false, $include_unassigned_new = false, $agent_team_id = null) {
-    $base_query = "SELECT t.TicketID, t.Title, t.Description, t.StatusID, t.PriorityID, t.TeamID, t.ContactName, t.ContactPhone, t.ContactEmail, a.AgentName AS CreatedByName, t.Source, s.StatusName, s.ColorCode as StatusColor, p.PriorityName, p.ColorCode as PriorityColor, team.TeamName, team.TeamColor, strftime('%d.%m.%Y %H:%M', t.CreatedAt) as CreatedAt, t.CreatedAt as CreatedAtTS, CAST(julianday('now') - julianday(t.CreatedAt) AS INT) as AgeDays, COALESCE(u.LastUpdatedAt, t.CreatedAt) as LastUpdatedTS, CAST(julianday('now') - julianday(COALESCE(u.LastUpdatedAt, t.CreatedAt)) AS INT) as LastUpdatedDays, GROUP_CONCAT(ta.AgentName, ', ') as AssignedAgents, COUNT(ta.AgentID) as AssignedCount FROM Tickets t JOIN TicketStatus s ON t.StatusID = s.StatusID JOIN TicketPriorities p ON t.PriorityID = p.PriorityID JOIN Teams team ON t.TeamID = team.TeamID JOIN Agents a ON t.CreatedByAgentID = a.AgentID LEFT JOIN (SELECT TicketID, MAX(UpdatedAt) AS LastUpdatedAt FROM TicketUpdates GROUP BY TicketID) u ON t.TicketID = u.TicketID LEFT JOIN (SELECT ta1.TicketID, ta1.AgentID, ta1.AgentName FROM TicketAssignees ta1 JOIN (SELECT TicketID, MAX(AssignedAt) AS MaxAssignedAt FROM TicketAssignees GROUP BY TicketID) ta2 ON ta1.TicketID = ta2.TicketID AND ta1.AssignedAt = ta2.MaxAssignedAt) ta ON t.TicketID = ta.TicketID";
+function get_tickets_with_filters($team_id = null, $status_filter = 'open', $search_term = null, $agent_id = null, $assigned_only = false, $include_unassigned_new = false, $agent_team_id = null, $person = null, $facility = null) {
+    $base_query = "SELECT t.TicketID, t.Title, t.Description, t.StatusID, t.PriorityID, t.TeamID, COALESCE(emp.FirstName || ' ' || emp.LastName, t.ContactName) AS ContactName, t.ContactPhone, t.ContactEmail, a.AgentName AS CreatedByName, t.Source, s.StatusName, s.ColorCode as StatusColor, p.PriorityName, p.ColorCode as PriorityColor, team.TeamName, team.TeamColor, fac.Facility AS FacilityName, strftime('%d.%m.%Y %H:%M', t.CreatedAt) as CreatedAt, t.CreatedAt as CreatedAtTS, CAST(julianday('now') - julianday(t.CreatedAt) AS INT) as AgeDays, COALESCE(u.LastUpdatedAt, t.CreatedAt) as LastUpdatedTS, CAST(julianday('now') - julianday(COALESCE(u.LastUpdatedAt, t.CreatedAt)) AS INT) as LastUpdatedDays, GROUP_CONCAT(ta.AgentName, ', ') as AssignedAgents, COUNT(ta.AgentID) as AssignedCount FROM Tickets t JOIN TicketStatus s ON t.StatusID = s.StatusID JOIN TicketPriorities p ON t.PriorityID = p.PriorityID JOIN Teams team ON t.TeamID = team.TeamID JOIN Agents a ON t.CreatedByAgentID = a.AgentID LEFT JOIN Employees emp ON t.ContactEmployeeID = emp.EmployeeID LEFT JOIN Facilities fac ON t.FacilityID = fac.FacilityID LEFT JOIN (SELECT TicketID, MAX(UpdatedAt) AS LastUpdatedAt FROM TicketUpdates GROUP BY TicketID) u ON t.TicketID = u.TicketID LEFT JOIN (SELECT ta1.TicketID, ta1.AgentID, ta1.AgentName FROM TicketAssignees ta1 JOIN (SELECT TicketID, MAX(AssignedAt) AS MaxAssignedAt FROM TicketAssignees GROUP BY TicketID) ta2 ON ta1.TicketID = ta2.TicketID AND ta1.AssignedAt = ta2.MaxAssignedAt) ta ON t.TicketID = ta.TicketID";
     $conditions = [];
     $params = [];
     if ($team_id) { $conditions[] = 't.TeamID = ?'; $params[] = $team_id; }
@@ -53,10 +53,21 @@ function get_tickets_with_filters($team_id = null, $status_filter = 'open', $sea
     } elseif ($status_filter !== 'all') {
         $conditions[] = 's.StatusName = ?'; $params[] = $status_filter; }
     if ($search_term) {
-        $conditions[] = '(t.Title LIKE ? OR t.TicketID = ? OR t.ContactName LIKE ?)';
+        $conditions[] = "(t.Title LIKE ? OR t.TicketID = ? OR t.ContactName LIKE ? OR (emp.FirstName || ' ' || emp.LastName) LIKE ? OR fac.Facility LIKE ? )";
         $params[] = "%$search_term%";
         $params[] = ctype_digit($search_term) ? $search_term : -1;
         $params[] = "%$search_term%";
+        $params[] = "%$search_term%";
+        $params[] = "%$search_term%";
+    }
+    if ($person) {
+        $conditions[] = "((emp.FirstName || ' ' || emp.LastName) LIKE ? OR t.ContactName LIKE ?)";
+        $params[] = "%$person%";
+        $params[] = "%$person%";
+    }
+    if ($facility) {
+        $conditions[] = 'fac.Facility LIKE ?';
+        $params[] = "%$facility%";
     }
     if ($agent_id) {
         if ($assigned_only) {
@@ -86,9 +97,21 @@ function get_ticket_by_id($ticket_id) {
     return query_db($query, [$ticket_id], true);
 }
 
-function search_tickets($term, $limit = 10) {
-    $query = "SELECT TicketID, Title FROM Tickets WHERE Title LIKE ? OR CAST(TicketID AS TEXT) LIKE ? OR ContactName LIKE ? ORDER BY CreatedAt DESC LIMIT ?";
-    return query_db($query, ["%$term%", "%$term%", "%$term%", $limit]);
+function search_tickets($term, $person = null, $facility = null, $limit = 10) {
+    $query = "SELECT t.TicketID, t.Title, COALESCE(emp.FirstName || ' ' || emp.LastName, t.ContactName) AS PersonName, fac.Facility AS FacilityName FROM Tickets t LEFT JOIN Employees emp ON t.ContactEmployeeID = emp.EmployeeID LEFT JOIN Facilities fac ON t.FacilityID = fac.FacilityID WHERE (t.Title LIKE ? OR CAST(t.TicketID AS TEXT) LIKE ? OR COALESCE(emp.FirstName || ' ' || emp.LastName, t.ContactName) LIKE ? OR fac.Facility LIKE ?)";
+    $params = ["%$term%", "%$term%", "%$term%", "%$term%"];
+    if ($person) {
+        $query .= " AND ((emp.FirstName || ' ' || emp.LastName) LIKE ? OR t.ContactName LIKE ?)";
+        $params[] = "%$person%";
+        $params[] = "%$person%";
+    }
+    if ($facility) {
+        $query .= " AND fac.Facility LIKE ?";
+        $params[] = "%$facility%";
+    }
+    $query .= " ORDER BY t.CreatedAt DESC LIMIT ?";
+    $params[] = $limit;
+    return query_db($query, $params);
 }
 
 // ----------------------------------------------------------------------

--- a/php/templates/dashboard.php
+++ b/php/templates/dashboard.php
@@ -4,6 +4,8 @@ include 'templates/header.php';
 if (!isset($current_team_filter)) $current_team_filter = 'mine';
 if (!isset($current_status_filter)) $current_status_filter = 'open';
 if (!isset($search_term)) $search_term = '';
+if (!isset($person_term)) $person_term = '';
+if (!isset($facility_term)) $facility_term = '';
 if (!isset($current_agent_filter)) $current_agent_filter = '';
 ?>
 <div class="dashboard">
@@ -47,9 +49,11 @@ if (!isset($current_agent_filter)) $current_agent_filter = '';
                 </select>
             </div>
             <div class="filter-group search-group">
-                <label>Suche:</label>
+                <label>Titel, ID, Person oder Einrichtung:</label>
                 <div class="search-bar">
-                    <input type="text" id="search-input" value="<?php echo htmlspecialchars($search_term); ?>" placeholder="Titel oder ID">
+                    <input type="text" id="search-input" value="<?php echo htmlspecialchars($search_term); ?>" placeholder="Titel, ID, Person oder Einrichtung">
+                    <input type="text" id="person-input" value="<?php echo htmlspecialchars($person_term); ?>" placeholder="Person">
+                    <input type="text" id="facility-input" value="<?php echo htmlspecialchars($facility_term); ?>" placeholder="Einrichtung">
                     <button onclick="applyFilters()">Suchen</button>
                 </div>
             </div>
@@ -106,18 +110,27 @@ function applyFilters() {
     const status = document.getElementById('status-filter').value;
     const agent = document.getElementById('agent-filter').value;
     const search = document.getElementById('search-input').value;
+    const person = document.getElementById('person-input').value;
+    const facility = document.getElementById('facility-input').value;
 
     const url = new URL(window.location);
     url.searchParams.set('team', team);
     url.searchParams.set('status', status);
     if (agent) { url.searchParams.set('agent', agent); } else { url.searchParams.delete('agent'); }
     if (search) { url.searchParams.set('q', search); } else { url.searchParams.delete('q'); }
+    if (person) { url.searchParams.set('person', person); } else { url.searchParams.delete('person'); }
+    if (facility) { url.searchParams.set('facility', facility); } else { url.searchParams.delete('facility'); }
     window.location = url;
 }
-document.getElementById('search-input').addEventListener('keydown', function(e) {
-    if (e.key === 'Enter') {
-        e.preventDefault();
-        applyFilters();
+['search-input','person-input','facility-input'].forEach(function(id) {
+    const el = document.getElementById(id);
+    if (el) {
+        el.addEventListener('keydown', function(e) {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                applyFilters();
+            }
+        });
     }
 });
 </script>


### PR DESCRIPTION
## Summary
- allow filtering tickets by person or facility
- join employee and facility data for ticket queries
- update dashboard search UI with separate person and facility fields

## Testing
- `php -l php/models.php`
- `php -l php/api/search_tickets.php`
- `php -l php/index.php`
- `php -l php/templates/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbfed848bc8327afa33fd1fb93aa55