### PR TITLE
Expand open ticket filters to exclude closed statuses

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -379,9 +379,17 @@ if ($agent_filter_param) {
 
 $tickets = get_tickets_with_filters($team_id, $status_filter, $search_value ?: null, $filter_agent, $assigned_only, $include_global_new, $agent['TeamID'], $person_value ?: null, $facility_value ?: null);
 
+$statuses = get_all_statuses();
+$closed_statuses = ['Gelöst', 'Storniert'];
+$open_statuses = [];
+foreach ($statuses as $status) {
+    if (!in_array($status['StatusName'], $closed_statuses, true)) {
+        $open_statuses[] = $status['StatusName'];
+    }
+}
+
 $new_ticket_count = 0;
 $open_ticket_count = 0;
-$open_statuses = ['Neu', 'In Arbeit', 'Wartend'];
 
 // mark unassigned new tickets that exceed configured thresholds and stale tickets
 foreach ($tickets as &$t) {
@@ -401,12 +409,11 @@ foreach ($tickets as &$t) {
     if ($t['StatusName'] === 'Neu') {
         $new_ticket_count++;
     }
-    if (in_array($t['StatusName'], $open_statuses, true)) {
+    if (!in_array($t['StatusName'], $closed_statuses, true)) {
         $open_ticket_count++;
     }
 }
 unset($t);
-$statuses = get_all_statuses();
 $agents = load_agents();
 $current_status_filter = $status_filter;
 $current_agent_filter = $agent_filter_param;

--- a/php/models.php
+++ b/php/models.php
@@ -24,7 +24,7 @@ function get_agent_by_token($token) {
 
 function get_agents_with_ticket_counts() {
     $query = "SELECT a.AgentID, a.AgentName, a.TeamID, t.TeamName, " .
-             "COUNT(CASE WHEN s.StatusName IN ('Neu','In Arbeit','Wartend') THEN 1 END) AS OpenTickets, " .
+             "COUNT(CASE WHEN s.StatusName NOT IN ('Gelöst','Storniert') THEN 1 END) AS OpenTickets, " .
              "COUNT(DISTINCT tu.TicketID) AS SolvedTickets " .
              "FROM Agents a " .
              "JOIN Teams t ON a.TeamID = t.TeamID " .
@@ -49,7 +49,7 @@ function get_tickets_with_filters($team_id = null, $status_filter = 'open', $sea
     $params = [];
     if ($team_id) { $conditions[] = 't.TeamID = ?'; $params[] = $team_id; }
     if ($status_filter === 'open') {
-        $conditions[] = "s.StatusName IN ('Neu','In Arbeit','Wartend')"; // offen
+        $conditions[] = "s.StatusName NOT IN ('Gelöst','Storniert')"; // offen
     } elseif ($status_filter !== 'all') {
         $conditions[] = 's.StatusName = ?'; $params[] = $status_filter; }
     if ($search_term) {


### PR DESCRIPTION
## Summary
- treat tickets as open when their status is not `Gelöst` or `Storniert`, ensuring inquiry states stay visible in the open filter
- derive the dashboard's open-status list from the database and reuse the same closed-status exclusions for counting
- align agent overview statistics with the updated open-ticket definition

## Testing
- php -l php/models.php
- php -l php/index.php

------
https://chatgpt.com/codex/tasks/task_e_68ca4e1ecba48327ae852bad3cd6529f