### PR TITLE
Vereinheitlichte Dashboard-Suche

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -351,8 +351,6 @@ if ($action === 'view_markdown') {
 $team_filter = $_GET['team'] ?? 'mine';
 $status_filter = $_GET['status'] ?? 'open';
 $search_value = trim($_GET['q'] ?? '');
-$person_value = trim($_GET['person'] ?? '');
-$facility_value = trim($_GET['facility'] ?? '');
 $agent_filter_param = $_GET['agent'] ?? null;
 
 $team_id = null;
@@ -377,7 +375,7 @@ if ($agent_filter_param) {
     $assigned_only = true;
 }
 
-$tickets = get_tickets_with_filters($team_id, $status_filter, $search_value ?: null, $filter_agent, $assigned_only, $include_global_new, $agent['TeamID'], $person_value ?: null, $facility_value ?: null);
+$tickets = get_tickets_with_filters($team_id, $status_filter, $search_value ?: null, $filter_agent, $assigned_only, $include_global_new, $agent['TeamID']);
 
 $statuses = get_all_statuses();
 $closed_statuses = ['Gelöst', 'Storniert'];
@@ -418,6 +416,4 @@ $agents = load_agents();
 $current_status_filter = $status_filter;
 $current_agent_filter = $agent_filter_param;
 $search_term = $search_value;
-$person_term = $person_value;
-$facility_term = $facility_value;
 include 'templates/dashboard.php';

--- a/php/models.php
+++ b/php/models.php
@@ -43,7 +43,7 @@ function get_agents_with_ticket_counts() {
     return query_db($query);
 }
 
-function get_tickets_with_filters($team_id = null, $status_filter = 'open', $search_term = null, $agent_id = null, $assigned_only = false, $include_unassigned_new = false, $agent_team_id = null, $person = null, $facility = null) {
+function get_tickets_with_filters($team_id = null, $status_filter = 'open', $search_term = null, $agent_id = null, $assigned_only = false, $include_unassigned_new = false, $agent_team_id = null) {
     $base_query = "SELECT t.TicketID, t.Title, t.Description, t.StatusID, t.PriorityID, t.TeamID, COALESCE(emp.FirstName || ' ' || emp.LastName, t.ContactName) AS ContactName, t.ContactPhone, t.ContactEmail, a.AgentName AS CreatedByName, t.Source, s.StatusName, s.ColorCode as StatusColor, p.PriorityName, p.ColorCode as PriorityColor, team.TeamName, team.TeamColor, fac.Facility AS FacilityName, strftime('%d.%m.%Y %H:%M', t.CreatedAt) as CreatedAt, t.CreatedAt as CreatedAtTS, CAST(julianday('now') - julianday(t.CreatedAt) AS INT) as AgeDays, COALESCE(u.LastUpdatedAt, t.CreatedAt) as LastUpdatedTS, CAST(julianday('now') - julianday(COALESCE(u.LastUpdatedAt, t.CreatedAt)) AS INT) as LastUpdatedDays, GROUP_CONCAT(ta.AgentName, ', ') as AssignedAgents, COUNT(ta.AgentID) as AssignedCount FROM Tickets t JOIN TicketStatus s ON t.StatusID = s.StatusID JOIN TicketPriorities p ON t.PriorityID = p.PriorityID JOIN Teams team ON t.TeamID = team.TeamID JOIN Agents a ON t.CreatedByAgentID = a.AgentID LEFT JOIN address.Employees emp ON t.ContactEmployeeID = emp.EmployeeID LEFT JOIN address.Facilities fac ON t.FacilityID = fac.FacilityID LEFT JOIN (SELECT TicketID, MAX(UpdatedAt) AS LastUpdatedAt FROM TicketUpdates GROUP BY TicketID) u ON t.TicketID = u.TicketID LEFT JOIN (SELECT ta1.TicketID, ta1.AgentID, ta1.AgentName FROM TicketAssignees ta1 JOIN (SELECT TicketID, MAX(AssignedAt) AS MaxAssignedAt FROM TicketAssignees GROUP BY TicketID) ta2 ON ta1.TicketID = ta2.TicketID AND ta1.AssignedAt = ta2.MaxAssignedAt) ta ON t.TicketID = ta.TicketID";
     $conditions = [];
     $params = [];
@@ -53,21 +53,13 @@ function get_tickets_with_filters($team_id = null, $status_filter = 'open', $sea
     } elseif ($status_filter !== 'all') {
         $conditions[] = 's.StatusName = ?'; $params[] = $status_filter; }
     if ($search_term) {
-        $conditions[] = "(t.Title LIKE ? OR t.TicketID = ? OR t.ContactName LIKE ? OR (emp.FirstName || ' ' || emp.LastName) LIKE ? OR fac.Facility LIKE ? )";
-        $params[] = "%$search_term%";
-        $params[] = ctype_digit($search_term) ? $search_term : -1;
+        $conditions[] = "(t.Title LIKE ? OR t.Description LIKE ? OR CAST(t.TicketID AS TEXT) LIKE ? OR t.ContactName LIKE ? OR (emp.FirstName || ' ' || emp.LastName) LIKE ? OR fac.Facility LIKE ? )";
         $params[] = "%$search_term%";
         $params[] = "%$search_term%";
         $params[] = "%$search_term%";
-    }
-    if ($person) {
-        $conditions[] = "((emp.FirstName || ' ' || emp.LastName) LIKE ? OR t.ContactName LIKE ?)";
-        $params[] = "%$person%";
-        $params[] = "%$person%";
-    }
-    if ($facility) {
-        $conditions[] = 'fac.Facility LIKE ?';
-        $params[] = "%$facility%";
+        $params[] = "%$search_term%";
+        $params[] = "%$search_term%";
+        $params[] = "%$search_term%";
     }
     if ($agent_id) {
         if ($assigned_only) {

--- a/php/templates/dashboard.php
+++ b/php/templates/dashboard.php
@@ -3,8 +3,6 @@ $title = 'Dashboard - IFAK Ticketsystem';
 include 'templates/header.php';
 if (!isset($current_status_filter)) $current_status_filter = 'open';
 if (!isset($search_term)) $search_term = '';
-if (!isset($person_term)) $person_term = '';
-if (!isset($facility_term)) $facility_term = '';
 if (!isset($current_agent_filter)) $current_agent_filter = '';
 if (!isset($new_ticket_count)) $new_ticket_count = 0;
 if (!isset($open_ticket_count)) $open_ticket_count = 0;
@@ -39,11 +37,9 @@ if (!isset($open_ticket_count)) $open_ticket_count = 0;
                 </select>
             </div>
             <div class="filter-group search-group">
-                <label>Titel, ID, Person oder Einrichtung:</label>
+                <label>Titel, ID, Beschreibung, Kontakt oder Einrichtung:</label>
                 <div class="search-bar">
-                    <input type="text" id="search-input" value="<?php echo htmlspecialchars($search_term); ?>" placeholder="Titel, ID, Person oder Einrichtung">
-                    <input type="text" id="person-input" value="<?php echo htmlspecialchars($person_term); ?>" placeholder="Person">
-                    <input type="text" id="facility-input" value="<?php echo htmlspecialchars($facility_term); ?>" placeholder="Einrichtung">
+                    <input type="text" id="search-input" value="<?php echo htmlspecialchars($search_term); ?>" placeholder="Titel, ID, Beschreibung, Kontakt oder Einrichtung">
                     <button onclick="applyFilters()">Suchen</button>
                 </div>
             </div>
@@ -99,28 +95,24 @@ function applyFilters() {
     const status = document.getElementById('status-filter').value;
     const agent = document.getElementById('agent-filter').value;
     const search = document.getElementById('search-input').value;
-    const person = document.getElementById('person-input').value;
-    const facility = document.getElementById('facility-input').value;
 
     const url = new URL(window.location);
     url.searchParams.delete('team');
     url.searchParams.set('status', status);
     if (agent) { url.searchParams.set('agent', agent); } else { url.searchParams.delete('agent'); }
     if (search) { url.searchParams.set('q', search); } else { url.searchParams.delete('q'); }
-    if (person) { url.searchParams.set('person', person); } else { url.searchParams.delete('person'); }
-    if (facility) { url.searchParams.set('facility', facility); } else { url.searchParams.delete('facility'); }
+    url.searchParams.delete('person');
+    url.searchParams.delete('facility');
     window.location = url;
 }
-['search-input','person-input','facility-input'].forEach(function(id) {
-    const el = document.getElementById(id);
-    if (el) {
-        el.addEventListener('keydown', function(e) {
-            if (e.key === 'Enter') {
-                e.preventDefault();
-                applyFilters();
-            }
-        });
-    }
-});
+const searchInput = document.getElementById('search-input');
+if (searchInput) {
+    searchInput.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            applyFilters();
+        }
+    });
+}
 </script>
 <?php include 'templates/footer.php'; ?>


### PR DESCRIPTION
## Summary
- reduziere die drei bisherigen Dashboard-Suchfelder auf ein gemeinsames Eingabefeld
- erweitere die Ticket-Abfrage um die Suche in Beschreibung, Kontakt und Einrichtung
- säubere die Filterlogik, sodass alte person-/facility-Parameter entfernt werden

## Testing
- php -l php/index.php
- php -l php/models.php
- php -l php/templates/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68ca530b111083279c1fa3ad082ae19d