### PR TITLE
Add power search across ticket updates and locations

### DIFF
--- a/php/models.php
+++ b/php/models.php
@@ -44,7 +44,7 @@ function get_agents_with_ticket_counts() {
 }
 
 function get_tickets_with_filters($team_id = null, $status_filter = 'open', $search_term = null, $agent_id = null, $assigned_only = false, $include_unassigned_new = false, $agent_team_id = null) {
-    $base_query = "SELECT t.TicketID, t.Title, t.Description, t.StatusID, t.PriorityID, t.TeamID, COALESCE(emp.FirstName || ' ' || emp.LastName, t.ContactName) AS ContactName, t.ContactPhone, t.ContactEmail, a.AgentName AS CreatedByName, t.Source, s.StatusName, s.ColorCode as StatusColor, p.PriorityName, p.ColorCode as PriorityColor, team.TeamName, team.TeamColor, fac.Facility AS FacilityName, strftime('%d.%m.%Y %H:%M', t.CreatedAt) as CreatedAt, t.CreatedAt as CreatedAtTS, CAST(julianday('now') - julianday(t.CreatedAt) AS INT) as AgeDays, COALESCE(u.LastUpdatedAt, t.CreatedAt) as LastUpdatedTS, CAST(julianday('now') - julianday(COALESCE(u.LastUpdatedAt, t.CreatedAt)) AS INT) as LastUpdatedDays, GROUP_CONCAT(ta.AgentName, ', ') as AssignedAgents, COUNT(ta.AgentID) as AssignedCount FROM Tickets t JOIN TicketStatus s ON t.StatusID = s.StatusID JOIN TicketPriorities p ON t.PriorityID = p.PriorityID JOIN Teams team ON t.TeamID = team.TeamID JOIN Agents a ON t.CreatedByAgentID = a.AgentID LEFT JOIN address.Employees emp ON t.ContactEmployeeID = emp.EmployeeID LEFT JOIN address.Facilities fac ON t.FacilityID = fac.FacilityID LEFT JOIN (SELECT TicketID, MAX(UpdatedAt) AS LastUpdatedAt FROM TicketUpdates GROUP BY TicketID) u ON t.TicketID = u.TicketID LEFT JOIN (SELECT ta1.TicketID, ta1.AgentID, ta1.AgentName FROM TicketAssignees ta1 JOIN (SELECT TicketID, MAX(AssignedAt) AS MaxAssignedAt FROM TicketAssignees GROUP BY TicketID) ta2 ON ta1.TicketID = ta2.TicketID AND ta1.AssignedAt = ta2.MaxAssignedAt) ta ON t.TicketID = ta.TicketID";
+    $base_query = "SELECT t.TicketID, t.Title, t.Description, t.StatusID, t.PriorityID, t.TeamID, COALESCE(emp.FirstName || ' ' || emp.LastName, t.ContactName) AS ContactName, t.ContactPhone, t.ContactEmail, a.AgentName AS CreatedByName, t.Source, s.StatusName, s.ColorCode as StatusColor, p.PriorityName, p.ColorCode as PriorityColor, team.TeamName, team.TeamColor, fac.Facility AS FacilityName, loc.Location AS LocationName, strftime('%d.%m.%Y %H:%M', t.CreatedAt) as CreatedAt, t.CreatedAt as CreatedAtTS, CAST(julianday('now') - julianday(t.CreatedAt) AS INT) as AgeDays, COALESCE(u.LastUpdatedAt, t.CreatedAt) as LastUpdatedTS, CAST(julianday('now') - julianday(COALESCE(u.LastUpdatedAt, t.CreatedAt)) AS INT) as LastUpdatedDays, GROUP_CONCAT(ta.AgentName, ', ') as AssignedAgents, COUNT(ta.AgentID) as AssignedCount FROM Tickets t JOIN TicketStatus s ON t.StatusID = s.StatusID JOIN TicketPriorities p ON t.PriorityID = p.PriorityID JOIN Teams team ON t.TeamID = team.TeamID JOIN Agents a ON t.CreatedByAgentID = a.AgentID LEFT JOIN address.Employees emp ON t.ContactEmployeeID = emp.EmployeeID LEFT JOIN address.Facilities fac ON t.FacilityID = fac.FacilityID LEFT JOIN address.Locations loc ON loc.LocationID = COALESCE(t.LocationID, fac.LocationID) LEFT JOIN (SELECT TicketID, MAX(UpdatedAt) AS LastUpdatedAt FROM TicketUpdates GROUP BY TicketID) u ON t.TicketID = u.TicketID LEFT JOIN (SELECT ta1.TicketID, ta1.AgentID, ta1.AgentName FROM TicketAssignees ta1 JOIN (SELECT TicketID, MAX(AssignedAt) AS MaxAssignedAt FROM TicketAssignees GROUP BY TicketID) ta2 ON ta1.TicketID = ta2.TicketID AND ta1.AssignedAt = ta2.MaxAssignedAt) ta ON t.TicketID = ta.TicketID";
     $conditions = [];
     $params = [];
     if ($team_id) { $conditions[] = 't.TeamID = ?'; $params[] = $team_id; }
@@ -53,13 +53,11 @@ function get_tickets_with_filters($team_id = null, $status_filter = 'open', $sea
     } elseif ($status_filter !== 'all') {
         $conditions[] = 's.StatusName = ?'; $params[] = $status_filter; }
     if ($search_term) {
-        $conditions[] = "(t.Title LIKE ? OR t.Description LIKE ? OR CAST(t.TicketID AS TEXT) LIKE ? OR t.ContactName LIKE ? OR (emp.FirstName || ' ' || emp.LastName) LIKE ? OR fac.Facility LIKE ? )";
-        $params[] = "%$search_term%";
-        $params[] = "%$search_term%";
-        $params[] = "%$search_term%";
-        $params[] = "%$search_term%";
-        $params[] = "%$search_term%";
-        $params[] = "%$search_term%";
+        $conditions[] = "(t.Title LIKE ? OR t.Description LIKE ? OR CAST(t.TicketID AS TEXT) LIKE ? OR t.ContactName LIKE ? OR (emp.FirstName || ' ' || emp.LastName) LIKE ? OR fac.Facility LIKE ? OR loc.Location LIKE ? OR EXISTS (SELECT 1 FROM TicketUpdates tu WHERE tu.TicketID = t.TicketID AND (tu.UpdateText LIKE ? OR tu.UpdatedByName LIKE ?)))";
+        $like = "%$search_term%";
+        $params = array_merge($params, array_fill(0, 7, $like));
+        $params[] = $like;
+        $params[] = $like;
     }
     if ($agent_id) {
         if ($assigned_only) {
@@ -90,15 +88,19 @@ function get_ticket_by_id($ticket_id) {
 }
 
 function search_tickets($term, $person = null, $facility = null, $limit = 10) {
-    $query = "SELECT t.TicketID, t.Title, COALESCE(emp.FirstName || ' ' || emp.LastName, t.ContactName) AS PersonName, fac.Facility AS FacilityName FROM Tickets t LEFT JOIN address.Employees emp ON t.ContactEmployeeID = emp.EmployeeID LEFT JOIN address.Facilities fac ON t.FacilityID = fac.FacilityID WHERE (t.Title LIKE ? OR CAST(t.TicketID AS TEXT) LIKE ? OR COALESCE(emp.FirstName || ' ' || emp.LastName, t.ContactName) LIKE ? OR fac.Facility LIKE ?)";
-    $params = ["%$term%", "%$term%", "%$term%", "%$term%"];
+    $query = "SELECT t.TicketID, t.Title, COALESCE(emp.FirstName || ' ' || emp.LastName, t.ContactName) AS PersonName, fac.Facility AS FacilityName, loc.Location AS LocationName FROM Tickets t LEFT JOIN address.Employees emp ON t.ContactEmployeeID = emp.EmployeeID LEFT JOIN address.Facilities fac ON t.FacilityID = fac.FacilityID LEFT JOIN address.Locations loc ON loc.LocationID = COALESCE(t.LocationID, fac.LocationID) WHERE (t.Title LIKE ? OR t.Description LIKE ? OR CAST(t.TicketID AS TEXT) LIKE ? OR COALESCE(emp.FirstName || ' ' || emp.LastName, t.ContactName) LIKE ? OR fac.Facility LIKE ? OR loc.Location LIKE ? OR EXISTS (SELECT 1 FROM TicketUpdates tu WHERE tu.TicketID = t.TicketID AND (tu.UpdateText LIKE ? OR tu.UpdatedByName LIKE ?)))";
+    $like = "%$term%";
+    $params = array_fill(0, 6, $like);
+    $params[] = $like;
+    $params[] = $like;
     if ($person) {
         $query .= " AND ((emp.FirstName || ' ' || emp.LastName) LIKE ? OR t.ContactName LIKE ?)";
         $params[] = "%$person%";
         $params[] = "%$person%";
     }
     if ($facility) {
-        $query .= " AND fac.Facility LIKE ?";
+        $query .= " AND (fac.Facility LIKE ? OR loc.Location LIKE ?)";
+        $params[] = "%$facility%";
         $params[] = "%$facility%";
     }
     $query .= " ORDER BY t.CreatedAt DESC LIMIT ?";

--- a/php/templates/dashboard.php
+++ b/php/templates/dashboard.php
@@ -37,9 +37,9 @@ if (!isset($open_ticket_count)) $open_ticket_count = 0;
                 </select>
             </div>
             <div class="filter-group search-group">
-                <label>Titel, ID, Beschreibung, Kontakt oder Einrichtung:</label>
+                <label>Titel, ID, Beschreibung, Kontakt, Einrichtung, Standort oder Verlauf:</label>
                 <div class="search-bar">
-                    <input type="text" id="search-input" value="<?php echo htmlspecialchars($search_term); ?>" placeholder="Titel, ID, Beschreibung, Kontakt oder Einrichtung">
+                    <input type="text" id="search-input" value="<?php echo htmlspecialchars($search_term); ?>" placeholder="Titel, ID, Beschreibung, Kontakt, Einrichtung, Standort oder Verlauf">
                     <button onclick="applyFilters()">Suchen</button>
                 </div>
             </div>
@@ -55,6 +55,7 @@ if (!isset($open_ticket_count)) $open_ticket_count = 0;
                     <th>Priorität</th>
                     <th>Titel</th>
                     <th>Kontakt</th>
+                    <th>Einrichtung / Standort</th>
                     <th>Zugewiesen an</th>
                     <th>Erstellt am</th>
                     <th>Alter (Tage)</th>
@@ -71,6 +72,18 @@ if (!isset($open_ticket_count)) $open_ticket_count = 0;
                     <td><span class="priority-badge" style="background-color: <?php echo htmlspecialchars($ticket['PriorityColor']); ?>;"><?php echo htmlspecialchars($ticket['PriorityName']); ?></span></td>
                     <td><?php echo htmlspecialchars($ticket['Title']); ?></td>
                     <td><?php echo htmlspecialchars($ticket['ContactName']); ?></td>
+                    <td>
+                        <?php if (!empty($ticket['FacilityName']) || !empty($ticket['LocationName'])): ?>
+                            <?php if (!empty($ticket['FacilityName'])): ?>
+                                <div><?php echo htmlspecialchars($ticket['FacilityName']); ?></div>
+                            <?php endif; ?>
+                            <?php if (!empty($ticket['LocationName'])): ?>
+                                <div><small><?php echo htmlspecialchars($ticket['LocationName']); ?></small></div>
+                            <?php endif; ?>
+                        <?php else: ?>
+                            &ndash;
+                        <?php endif; ?>
+                    </td>
                     <td>
                         <?php if (!empty($ticket['AssignedAgents'])): ?>
                             <?php echo htmlspecialchars($ticket['AssignedAgents']); ?>


### PR DESCRIPTION
## Summary
- extend the dashboard ticket query with location details and a match against ticket update texts so the global search can find comments and organization data
- surface the facility/location information in the dashboard table and update the filter copy to explain the broader scope
- expand the ticket search API to cover descriptions, locations and update history while allowing facility filters to match location names as well

## Testing
- php -l php/models.php
- php -l php/templates/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68ca586b54488327862b544d39a4657d