### PR TITLE
Fix dashboard status filter to include new statuses

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -349,7 +349,11 @@ if ($action === 'view_markdown') {
 
 // default dashboard with filters
 $team_filter = $_GET['team'] ?? 'mine';
-$status_filter = $_GET['status'] ?? 'open';
+$status_filter_param = $_GET['status'] ?? 'open';
+$status_filter = $status_filter_param;
+if (is_string($status_filter_param) && ctype_digit($status_filter_param)) {
+    $status_filter = intval($status_filter_param);
+}
 $search_value = trim($_GET['q'] ?? '');
 $agent_filter_param = $_GET['agent'] ?? null;
 
@@ -413,7 +417,15 @@ foreach ($tickets as &$t) {
 }
 unset($t);
 $agents = load_agents();
-$current_status_filter = $status_filter;
+$current_status_filter = $status_filter_param;
+if ($status_filter_param !== 'open' && $status_filter_param !== 'all' && (!is_string($status_filter_param) || !ctype_digit($status_filter_param))) {
+    foreach ($statuses as $status_option) {
+        if ($status_option['StatusName'] === $status_filter_param) {
+            $current_status_filter = (string) $status_option['StatusID'];
+            break;
+        }
+    }
+}
 $current_agent_filter = $agent_filter_param;
 $search_term = $search_value;
 include 'templates/dashboard.php';

--- a/php/models.php
+++ b/php/models.php
@@ -51,7 +51,17 @@ function get_tickets_with_filters($team_id = null, $status_filter = 'open', $sea
     if ($status_filter === 'open') {
         $conditions[] = "s.StatusName NOT IN ('Gelöst','Storniert')"; // offen
     } elseif ($status_filter !== 'all') {
-        $conditions[] = 's.StatusName = ?'; $params[] = $status_filter; }
+        if (is_int($status_filter)) {
+            $conditions[] = 's.StatusID = ?';
+            $params[] = $status_filter;
+        } elseif (is_string($status_filter) && ctype_digit($status_filter)) {
+            $conditions[] = 's.StatusID = ?';
+            $params[] = intval($status_filter);
+        } else {
+            $conditions[] = 's.StatusName = ?';
+            $params[] = $status_filter;
+        }
+    }
     if ($search_term) {
         $conditions[] = "(t.Title LIKE ? OR t.Description LIKE ? OR CAST(t.TicketID AS TEXT) LIKE ? OR t.ContactName LIKE ? OR (emp.FirstName || ' ' || emp.LastName) LIKE ? OR fac.Facility LIKE ? OR loc.Location LIKE ? OR EXISTS (SELECT 1 FROM TicketUpdates tu WHERE tu.TicketID = t.TicketID AND (tu.UpdateText LIKE ? OR tu.UpdatedByName LIKE ?)))";
         $like = "%$search_term%";

--- a/php/templates/dashboard.php
+++ b/php/templates/dashboard.php
@@ -23,7 +23,7 @@ if (!isset($open_ticket_count)) $open_ticket_count = 0;
                     <option value="open" <?php if ($current_status_filter == 'open') echo 'selected'; ?>>Alle offenen</option>
                     <option value="all" <?php if ($current_status_filter == 'all') echo 'selected'; ?>>Alle</option>
                     <?php foreach ($statuses as $s): ?>
-                    <option value="<?php echo $s['StatusName']; ?>" <?php if ($current_status_filter == $s['StatusName']) echo 'selected'; ?>><?php echo htmlspecialchars($s['StatusName']); ?></option>
+                    <option value="<?php echo htmlspecialchars((string)$s['StatusID']); ?>" <?php if ((string)$current_status_filter === (string)$s['StatusID']) echo 'selected'; ?>><?php echo htmlspecialchars($s['StatusName']); ?></option>
                     <?php endforeach; ?>
                 </select>
             </div>


### PR DESCRIPTION
## Summary
- nutze Status-IDs im Dashboard-Filter, damit neu angelegte Stati angezeigt und korrekt ausgewählt werden
- verarbeite weiterhin alte Links mit Statusnamen und setze die Auswahl im UI passend
- erweitere die Ticketabfrage um Filter per Status-ID

## Testing
- php -l php/index.php
- php -l php/models.php
- php -l php/templates/dashboard.php


------
https://chatgpt.com/codex/tasks/task_e_68cc43f1fa4883279eac7033191c04c7