### PR TITLE
Ensure QC email is sent without contact address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ ignore/
 
 # macOS
 .DS_Store
+
+# Test Artefakte
+php/tests/mail_output.log

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -116,7 +116,6 @@ function send_assignment_email($agent_email, $agent_name, $ticket) {
 }
 
 function send_solution_email($ticket, $updates) {
-    if (empty($ticket['ContactEmail'])) return;
     global $QUALITY_CONTROL_EMAIL, $HELPDESK_FROM;
     $base_url = get_base_url();
     $link = $base_url . '/index.php?action=view_ticket&id=' . $ticket['TicketID'];
@@ -135,8 +134,11 @@ function send_solution_email($ticket, $updates) {
     if (!empty($QUALITY_CONTROL_EMAIL)) {
         @mail($QUALITY_CONTROL_EMAIL, $subject, $body, "From: $HELPDESK_FROM");
     }
-    $submitter = $ticket['ContactEmail'];
-    @mail($submitter, $subject, $body, "From: $HELPDESK_FROM");
+
+    $submitter = $ticket['ContactEmail'] ?? null;
+    if (!empty($submitter)) {
+        @mail($submitter, $subject, $body, "From: $HELPDESK_FROM");
+    }
 }
 
 function markdown_to_html($text) {

--- a/php/tests/fake_mail.php
+++ b/php/tests/fake_mail.php
@@ -1,0 +1,8 @@
+#!/usr/bin/env php
+<?php
+$logFile = __DIR__ . '/mail_output.log';
+$entry = "=== MAIL ===\n";
+$entry .= 'ARGS: ' . json_encode(array_slice($argv, 1)) . "\n";
+$entry .= "DATA:\n" . stream_get_contents(STDIN) . "\n";
+$entry .= "=== END ===\n";
+file_put_contents($logFile, $entry, FILE_APPEND);

--- a/php/tests/send_solution_email_test.php
+++ b/php/tests/send_solution_email_test.php
@@ -1,0 +1,77 @@
+<?php
+require_once __DIR__ . '/../helpers.php';
+
+error_reporting(E_ALL);
+
+set_error_handler(function ($severity, $message, $file, $line) {
+    if (!(error_reporting() & $severity)) {
+        return false;
+    }
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+$logFile = __DIR__ . '/mail_output.log';
+if (file_exists($logFile)) {
+    unlink($logFile);
+}
+
+$desiredScript = realpath(__DIR__ . '/fake_mail.php');
+$currentPath = ini_get('sendmail_path');
+if (strpos($currentPath, $desiredScript) === false) {
+    $candidate = PHP_BINARY . ' ' . escapeshellarg($desiredScript);
+    ini_set('sendmail_path', $candidate);
+    $currentPath = ini_get('sendmail_path');
+}
+
+if (strpos($currentPath, $desiredScript) === false) {
+    restore_error_handler();
+    fwrite(STDERR, 'Fehler: sendmail_path nicht auf fake_mail.php gesetzt.' . PHP_EOL);
+    exit(1);
+}
+
+global $QUALITY_CONTROL_EMAIL;
+
+$ticket = [
+    'TicketID' => 999,
+    'Title' => 'Testticket',
+    'Description' => 'Beschreibung',
+    'ContactName' => 'Kontakt Person',
+    'ContactEmail' => null
+];
+
+$updates = [
+    [
+        'IsSolution' => 1,
+        'UpdatedByName' => 'Agent Tester',
+        'FormattedUpdatedAt' => '01.01.2024 12:00',
+        'UpdateText' => 'Lösung wurde dokumentiert.'
+    ]
+];
+
+try {
+    send_solution_email($ticket, $updates);
+    restore_error_handler();
+} catch (Throwable $e) {
+    restore_error_handler();
+    fwrite(STDERR, 'Fehler: ' . $e->getMessage() . PHP_EOL);
+    exit(1);
+}
+
+if (!file_exists($logFile)) {
+    fwrite(STDERR, "Fehler: Keine Mail protokolliert." . PHP_EOL);
+    exit(1);
+}
+
+$content = file_get_contents($logFile);
+$occurrences = substr_count($content, '=== MAIL ===');
+if ($occurrences !== 1) {
+    fwrite(STDERR, 'Fehler: Erwartet 1 Mail, gefunden ' . $occurrences . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($content, 'To: ' . $QUALITY_CONTROL_EMAIL) === false) {
+    fwrite(STDERR, 'Fehler: Qualitätskontrolladresse nicht gefunden.' . PHP_EOL);
+    exit(1);
+}
+
+echo "OK\n";


### PR DESCRIPTION
## Summary
- allow `send_solution_email` to always deliver to the quality control mailbox while skipping missing submitter addresses
- add a CLI test harness and fake sendmail script to verify behaviour when no contact email is present
- ignore the generated test mail log file

## Testing
- `php -d sendmail_path="$(command -v php) /workspace/t3/php/tests/fake_mail.php" tests/send_solution_email_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68cc48a2d0208327ae0e2239d619d937