### PR TITLE
Use configured extensions for attachment inputs

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -13,6 +13,37 @@ function allowed_file($filename) {
     return in_array($ext, $ALLOWED_EXTENSIONS);
 }
 
+function get_allowed_extension_strings() {
+    global $ALLOWED_EXTENSIONS;
+
+    if (!is_array($ALLOWED_EXTENSIONS)) {
+        return ['accept' => '', 'hint' => ''];
+    }
+
+    $extensions = [];
+    foreach ($ALLOWED_EXTENSIONS as $ext) {
+        if (!is_string($ext)) {
+            continue;
+        }
+        $clean = strtolower(trim($ext));
+        if ($clean === '') {
+            continue;
+        }
+        if (!in_array($clean, $extensions, true)) {
+            $extensions[] = $clean;
+        }
+    }
+
+    if (empty($extensions)) {
+        return ['accept' => '', 'hint' => ''];
+    }
+
+    $accept = '.' . implode(',.', $extensions);
+    $hint = implode(', ', $extensions);
+
+    return ['accept' => $accept, 'hint' => $hint];
+}
+
 function get_local_timestamp() {
     $dt = new DateTime('now', new DateTimeZone('Europe/Berlin'));
     return $dt->format('Y-m-d H:i:s');

--- a/php/index.php
+++ b/php/index.php
@@ -179,6 +179,9 @@ if ($action === 'new_ticket') {
     $priorities = get_all_priorities();
     $teams = get_all_teams();
     $agents = load_agents();
+    $allowed_extension_strings = get_allowed_extension_strings();
+    $allowed_accept = $allowed_extension_strings['accept'];
+    $allowed_hint = $allowed_extension_strings['hint'];
     include 'templates/ticket_form.php';
     exit;
 }
@@ -323,6 +326,9 @@ if ($action === 'view_ticket') {
     $statuses = get_all_statuses();
     $priorities = get_all_priorities();
     $agents = load_agents();
+    $allowed_extension_strings = get_allowed_extension_strings();
+    $allowed_accept = $allowed_extension_strings['accept'];
+    $allowed_hint = $allowed_extension_strings['hint'];
     include 'templates/ticket_view.php';
     exit;
 }

--- a/php/templates/ticket_form.php
+++ b/php/templates/ticket_form.php
@@ -75,8 +75,8 @@
         </div>
         <div class="form-group">
             <label for="attachment">Anhang:</label>
-            <input type="file" name="attachment" id="attachment" accept=".jpg,.jpeg,.png,.gif,.pdf,.doc,.docx,.txt,.zip">
-            <small class="form-hint">Erlaubte Dateiformate: jpg, jpeg, png, gif, pdf, doc, docx, txt, zip</small>
+            <input type="file" name="attachment" id="attachment" accept="<?php echo htmlspecialchars($allowed_accept ?? ''); ?>">
+            <small class="form-hint">Erlaubte Dateiformate: <?php echo htmlspecialchars($allowed_hint ?? ''); ?></small>
         </div>
         <div class="form-actions">
             <button type="submit" class="submit-button">Ticket erstellen</button>

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -239,8 +239,8 @@
                     </div>
                     <div class="form-group">
                         <label for="attachment">Anhang hinzufügen:</label>
-                        <input type="file" id="attachment" name="attachment" accept=".jpg,.jpeg,.png,.gif,.pdf,.doc,.docx,.txt,.zip">
-                        <small class="form-hint">Erlaubte Dateiformate: jpg, jpeg, png, gif, pdf, doc, docx, txt, zip</small>
+                        <input type="file" id="attachment" name="attachment" accept="<?php echo htmlspecialchars($allowed_accept ?? ''); ?>">
+                        <small class="form-hint">Erlaubte Dateiformate: <?php echo htmlspecialchars($allowed_hint ?? ''); ?></small>
                     </div>
                     <div class="form-actions">
                         <button type="submit" class="submit-button">Aktualisieren</button>


### PR DESCRIPTION
## Summary
- add a helper that formats the configured allowed extensions for upload controls
- pass the formatted accept attribute and hint text into the ticket form and update views
- render the allowed upload extensions dynamically so new extensions from the config are reflected automatically

## Testing
- php -l php/helpers.php
- php -l php/index.php
- php -l php/templates/ticket_form.php
- php -l php/templates/ticket_view.php

------
https://chatgpt.com/codex/tasks/task_e_68cce2d130d083279101311b09e43be2