### PR TITLE
Normalize mail body line endings

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -351,8 +351,9 @@ function send_mail_message($recipients, $subject, $body, $options = []) {
         }
 
         $mailer->Subject = $subject;
-        $mailer->Body = $body;
-        $mailer->AltBody = $body;
+        $normalizedBody = PHPMailer::normalizeBreaks((string)$body, PHPMailer::CRLF);
+        $mailer->Body = $normalizedBody;
+        $mailer->AltBody = $normalizedBody;
 
         $logContext = [
             'subject' => $subject,

--- a/php/tests/send_solution_email_test.php
+++ b/php/tests/send_solution_email_test.php
@@ -88,4 +88,27 @@ if (strpos($content, 'To: ' . $QUALITY_CONTROL_EMAIL) === false) {
     exit(1);
 }
 
+if (!preg_match('/Content-Type: text\/plain; charset=UTF-8\s+Content-Transfer-Encoding: base64\s+([A-Za-z0-9\/+=\s]+)/', $content, $matches)) {
+    fwrite(STDERR, 'Fehler: Plaintext-Teil der Mail nicht gefunden.' . PHP_EOL);
+    exit(1);
+}
+
+$base64Body = preg_replace('/\s+/', '', $matches[1]);
+$decodedBody = base64_decode($base64Body, true);
+if ($decodedBody === false) {
+    fwrite(STDERR, 'Fehler: Mailbody konnte nicht dekodiert werden.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($decodedBody, "\r\n") === false) {
+    fwrite(STDERR, 'Fehler: Mailbody enthält keine CRLF-Zeilenumbrüche.' . PHP_EOL);
+    exit(1);
+}
+
+$withoutCrlf = str_replace("\r\n", '', $decodedBody);
+if (strpos($withoutCrlf, "\n") !== false) {
+    fwrite(STDERR, 'Fehler: Mailbody enthält Zeilenumbrüche ohne CRLF.' . PHP_EOL);
+    exit(1);
+}
+
 echo "OK\n";


### PR DESCRIPTION
## Summary
- normalize PHPMailer bodies to CRLF line endings before sending
- extend the solution email test to decode the captured message and assert CRLF breaks

## Testing
- php php/tests/send_solution_email_test.php

------
https://chatgpt.com/codex/tasks/task_e_68cd3b2efa248327849f0239876e86b7