### PR TITLE
Avoid setting AltBody for plain text emails

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -367,7 +367,7 @@ function send_mail_message($recipients, $subject, $body, $options = []) {
         $mailer->Subject = $subject;
         $normalizedBody = PHPMailer::normalizeBreaks((string)$body, PHPMailer::CRLF);
         $mailer->Body = $normalizedBody;
-        $mailer->AltBody = $normalizedBody;
+        $mailer->AltBody = '';
 
         $logContext = [
             'subject' => $subject,


### PR DESCRIPTION
## Summary
- stop populating PHPMailer's AltBody when sending plain-text emails so only one body part is delivered

## Testing
- php -l php/helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68cd4802455483279177e6283b99e659