### PR TITLE
Passe Benachrichtigung bei gelösten Tickets an

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -539,35 +539,60 @@ function send_solution_email($ticket, $updates) {
     $base_url = get_base_url();
     $link = $base_url . '/index.php?action=view_ticket&id=' . $ticket['TicketID'];
     $subject = 'Ticket #' . $ticket['TicketID'] . ' - ' . $ticket['Title'] . ' - gelöst';
-    $lines = [
-        'Dein Ticket #' . $ticket['TicketID'] . ' wurde als gelöst markiert.',
+    $history = array_reverse($updates);
+
+    $quality_lines = [
+        'Das Ticket #' . $ticket['TicketID'] . ' wurde als gelöst markiert.',
         '',
         'Aufgabenstellung:',
         $ticket['Description'] ?? '',
         '',
         'Kommentarhistorie:',
     ];
-    $history = array_reverse($updates);
     foreach ($history as $u) {
         $prefix = $u['IsSolution'] ? '[Lösung] ' : '';
-        $lines[] = $prefix . $u['UpdatedByName'] . ' (' . $u['FormattedUpdatedAt'] . '):';
-        $lines[] = $u['UpdateText'];
-        $lines[] = '';
+        $quality_lines[] = $prefix . $u['UpdatedByName'] . ' (' . $u['FormattedUpdatedAt'] . '):';
+        $quality_lines[] = $u['UpdateText'];
+        $quality_lines[] = '';
     }
-    if (end($lines) === '') {
-        array_pop($lines);
+    if (end($quality_lines) === '') {
+        array_pop($quality_lines);
     }
-    $lines[] = '';
-    $lines[] = "Zum Ticket: $link";
-    $body = build_plaintext_mail_body($lines);
+    $quality_lines[] = '';
+    $quality_lines[] = "Zum Ticket: $link";
+    $quality_body = build_plaintext_mail_body($quality_lines);
 
     if (!empty($QUALITY_CONTROL_EMAIL)) {
-        send_mail_message($QUALITY_CONTROL_EMAIL, $subject, $body);
+        send_mail_message($QUALITY_CONTROL_EMAIL, $subject, $quality_body);
     }
 
     $submitter = $ticket['ContactEmail'] ?? null;
     if (!empty($submitter)) {
-        send_mail_message($submitter, $subject, $body);
+        $solution_lines = [
+            'Dein Ticket #' . $ticket['TicketID'] . ' wurde als gelöst markiert.',
+        ];
+        $solutions = [];
+        foreach ($history as $entry) {
+            if (!empty($entry['IsSolution'])) {
+                $solutions[] = $entry;
+            }
+        }
+        if (!empty($solutions)) {
+            $solution_lines[] = '';
+            $solution_lines[] = 'Lösung:';
+            foreach ($solutions as $solution) {
+                $solution_lines[] = $solution['UpdatedByName'] . ' (' . $solution['FormattedUpdatedAt'] . '):';
+                $solution_lines[] = $solution['UpdateText'];
+                $solution_lines[] = '';
+            }
+            if (end($solution_lines) === '') {
+                array_pop($solution_lines);
+            }
+        }
+        $solution_lines[] = '';
+        $solution_lines[] = "Zum Ticket: $link";
+        $solution_body = build_plaintext_mail_body($solution_lines);
+        send_mail_message($submitter, $subject, $solution_body);
     }
 }
 

--- a/php/tests/send_solution_email_test.php
+++ b/php/tests/send_solution_email_test.php
@@ -10,6 +10,27 @@ set_error_handler(function ($severity, $message, $file, $line) {
     throw new ErrorException($message, 0, $severity, $file, $line);
 });
 
+function extract_mail_entries($logContent) {
+    if (!preg_match_all('/=== MAIL ===\nARGS: [^\n]*\nDATA:\n(.+?)=== END ===\n/s', $logContent, $matches)) {
+        return [];
+    }
+    return $matches[1];
+}
+
+function decode_mail_body_from_raw($raw) {
+    if (!preg_match('/Content-Type: text\/plain; charset=UTF-8\s+Content-Transfer-Encoding: base64\s+([A-Za-z0-9\/+=\s]+)/', $raw, $matches)) {
+        return false;
+    }
+
+    $base64Body = preg_replace('/\s+/', '', $matches[1]);
+    $decodedBody = base64_decode($base64Body, true);
+    if ($decodedBody === false) {
+        return false;
+    }
+
+    return $decodedBody;
+}
+
 $logFile = __DIR__ . '/mail_output.log';
 if (file_exists($logFile)) {
     unlink($logFile);
@@ -77,26 +98,41 @@ if (!file_exists($logFile)) {
 }
 
 $content = file_get_contents($logFile);
-$occurrences = substr_count($content, '=== MAIL ===');
-if ($occurrences !== 1) {
-    fwrite(STDERR, 'Fehler: Erwartet 1 Mail, gefunden ' . $occurrences . PHP_EOL);
+$entries = extract_mail_entries($content);
+if (count($entries) !== 1) {
+    fwrite(STDERR, 'Fehler: Erwartet 1 Mail, gefunden ' . count($entries) . PHP_EOL);
     exit(1);
 }
 
-if (strpos($content, 'To: ' . $QUALITY_CONTROL_EMAIL) === false) {
+$qualityMail = $entries[0];
+if (strpos($qualityMail, 'To: ' . $QUALITY_CONTROL_EMAIL) === false) {
     fwrite(STDERR, 'Fehler: Qualitätskontrolladresse nicht gefunden.' . PHP_EOL);
     exit(1);
 }
 
-if (!preg_match('/Content-Type: text\/plain; charset=UTF-8\s+Content-Transfer-Encoding: base64\s+([A-Za-z0-9\/+=\s]+)/', $content, $matches)) {
-    fwrite(STDERR, 'Fehler: Plaintext-Teil der Mail nicht gefunden.' . PHP_EOL);
+$decodedBody = decode_mail_body_from_raw($qualityMail);
+if ($decodedBody === false) {
+    fwrite(STDERR, 'Fehler: Mailbody konnte nicht dekodiert werden.' . PHP_EOL);
     exit(1);
 }
 
-$base64Body = preg_replace('/\s+/', '', $matches[1]);
-$decodedBody = base64_decode($base64Body, true);
-if ($decodedBody === false) {
-    fwrite(STDERR, 'Fehler: Mailbody konnte nicht dekodiert werden.' . PHP_EOL);
+if (strpos($decodedBody, 'Das Ticket #999 wurde als gelöst markiert.') === false) {
+    fwrite(STDERR, 'Fehler: Einleitung für Qualitätskontrolle fehlt.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($decodedBody, 'Kommentarhistorie:') === false) {
+    fwrite(STDERR, 'Fehler: Kommentarhistorie fehlt in Qualitätskontrollmail.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($decodedBody, 'Lösung wurde dokumentiert.') === false) {
+    fwrite(STDERR, 'Fehler: Lösungseintrag fehlt in Qualitätskontrollmail.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($decodedBody, 'Dein Ticket') !== false) {
+    fwrite(STDERR, 'Fehler: Qualitätskontrollmail enthält Submitter-Anrede.' . PHP_EOL);
     exit(1);
 }
 
@@ -109,6 +145,146 @@ $withoutCrlf = str_replace("\r\n", '', $decodedBody);
 if (strpos($withoutCrlf, "\n") !== false) {
     fwrite(STDERR, 'Fehler: Mailbody enthält Zeilenumbrüche ohne CRLF.' . PHP_EOL);
     exit(1);
+}
+
+unlink($logFile);
+
+$ticket = [
+    'TicketID' => 1000,
+    'Title' => 'Testticket mit Submitter',
+    'Description' => 'Neue Beschreibung',
+    'ContactName' => 'Kontakt Person',
+    'ContactEmail' => 'kunde@example.com'
+];
+
+$updates = [
+    [
+        'IsSolution' => 0,
+        'UpdatedByName' => 'Qualitätsprüfer',
+        'FormattedUpdatedAt' => '02.01.2024 09:00',
+        'UpdateText' => 'Analyse durchgeführt.'
+    ],
+    [
+        'IsSolution' => 1,
+        'UpdatedByName' => 'Agent Tester',
+        'FormattedUpdatedAt' => '02.01.2024 10:00',
+        'UpdateText' => 'Problem gelöst.'
+    ]
+];
+
+send_solution_email($ticket, $updates);
+
+if (!file_exists($logFile)) {
+    fwrite(STDERR, "Fehler: Keine Mail für Submitter-Szenario protokolliert." . PHP_EOL);
+    exit(1);
+}
+
+$content = file_get_contents($logFile);
+$entries = extract_mail_entries($content);
+if (count($entries) !== 2) {
+    fwrite(STDERR, 'Fehler: Erwartet 2 Mails, gefunden ' . count($entries) . PHP_EOL);
+    exit(1);
+}
+
+$qualityMail = null;
+$submitterMail = null;
+foreach ($entries as $entry) {
+    if (strpos($entry, 'To: ' . $QUALITY_CONTROL_EMAIL) !== false) {
+        $qualityMail = $entry;
+    }
+    if (strpos($entry, 'To: kunde@example.com') !== false) {
+        $submitterMail = $entry;
+    }
+}
+
+if ($qualityMail === null) {
+    fwrite(STDERR, 'Fehler: Qualitätskontrollmail im Submitter-Szenario fehlt.' . PHP_EOL);
+    exit(1);
+}
+
+if ($submitterMail === null) {
+    fwrite(STDERR, 'Fehler: Submitter-Mail nicht gefunden.' . PHP_EOL);
+    exit(1);
+}
+
+$qualityBody = decode_mail_body_from_raw($qualityMail);
+if ($qualityBody === false) {
+    fwrite(STDERR, 'Fehler: Qualitätskontrollmail konnte nicht dekodiert werden.' . PHP_EOL);
+    exit(1);
+}
+
+$submitterBody = decode_mail_body_from_raw($submitterMail);
+if ($submitterBody === false) {
+    fwrite(STDERR, 'Fehler: Submitter-Mail konnte nicht dekodiert werden.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($qualityBody, 'Das Ticket #1000 wurde als gelöst markiert.') === false) {
+    fwrite(STDERR, 'Fehler: Einleitung in Qualitätskontrollmail (Submitter-Szenario) fehlt.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($qualityBody, 'Kommentarhistorie:') === false) {
+    fwrite(STDERR, 'Fehler: Kommentarhistorie fehlt in Qualitätskontrollmail (Submitter-Szenario).' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($qualityBody, 'Analyse durchgeführt.') === false) {
+    fwrite(STDERR, 'Fehler: Kommentar wurde in Qualitätskontrollmail nicht gefunden.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($qualityBody, 'Problem gelöst.') === false) {
+    fwrite(STDERR, 'Fehler: Lösung wurde in Qualitätskontrollmail nicht gefunden.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($qualityBody, 'Dein Ticket') !== false) {
+    fwrite(STDERR, 'Fehler: Qualitätskontrollmail enthält falsche Anrede.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($submitterBody, 'Dein Ticket #1000 wurde als gelöst markiert.') === false) {
+    fwrite(STDERR, 'Fehler: Einleitung in Submitter-Mail fehlt.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($submitterBody, 'Lösung:') === false) {
+    fwrite(STDERR, 'Fehler: Submitter-Mail enthält keine Lösungsüberschrift.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($submitterBody, 'Problem gelöst.') === false) {
+    fwrite(STDERR, 'Fehler: Lösungstext fehlt in Submitter-Mail.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($submitterBody, 'Analyse durchgeführt.') !== false) {
+    fwrite(STDERR, 'Fehler: Submitter-Mail enthält Kommentare ohne Lösung.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($submitterBody, 'Kommentarhistorie:') !== false) {
+    fwrite(STDERR, 'Fehler: Submitter-Mail enthält Kommentarhistorie.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($submitterBody, 'Aufgabenstellung:') !== false) {
+    fwrite(STDERR, 'Fehler: Submitter-Mail enthält Aufgabenstellung.' . PHP_EOL);
+    exit(1);
+}
+
+foreach (['Qualitätskontrolle' => $qualityBody, 'Submitter' => $submitterBody] as $label => $body) {
+    if (strpos($body, "\r\n") === false) {
+        fwrite(STDERR, 'Fehler: ' . $label . ' Mailbody enthält keine CRLF-Zeilenumbrüche.' . PHP_EOL);
+        exit(1);
+    }
+
+    $normalized = str_replace("\r\n", '', $body);
+    if (strpos($normalized, "\n") !== false) {
+        fwrite(STDERR, 'Fehler: ' . $label . ' Mailbody enthält Zeilenumbrüche ohne CRLF.' . PHP_EOL);
+        exit(1);
+    }
 }
 
 echo "OK\n";


### PR DESCRIPTION
## Summary
- passe den Mailtext für die Qualitätskontrolle an und halte die Kommentarhistorie bei
- sende dem Submitter nur den Lösungsteil des Tickets
- ergänze Tests für die neuen Inhalte und Empfänger der Versandmails

## Testing
- php tests/send_solution_email_test.php

------
https://chatgpt.com/codex/tasks/task_e_68cd5b7d8c6c8327acd9b08a82728671