### PR TITLE
Prevent empty solution submissions

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -194,8 +194,68 @@ if ($action === 'update_ticket') {
             $status_id = $_POST['status_id'] ?? '';
             $priority_id = $_POST['priority_id'] ?? '';
             $assign_agent = $_POST['assign_agent'] ?? '';
-            $update_text = trim($_POST['update_text'] ?? '');
+            $update_text_raw = $_POST['update_text'] ?? '';
+            $update_text = trim($update_text_raw);
             $is_solution = isset($_POST['is_solution']) ? 1 : 0;
+
+            if ($is_solution && $update_text === '') {
+                $flash = 'Bitte gib einen Kommentar ein, bevor du eine Lösung speicherst.';
+                $attachments = get_ticket_attachments($ticket_id);
+                $updates = get_ticket_updates($ticket_id);
+                $last_update_at = $updates ? $updates[0]['FormattedUpdatedAt'] : $ticket['CreatedAt'];
+                $assignees = get_ticket_assignees($ticket_id);
+                $related_person = [];
+                $related_facility = [];
+                $related_location = [];
+                $seen_ids = [];
+
+                if ($ticket['ContactEmployeeID']) {
+                    $related_person = get_related_tickets_by_person($ticket['ContactEmployeeID'], $ticket_id);
+                    foreach ($related_person as $rp) {
+                        $seen_ids[$rp['TicketID']] = true;
+                    }
+                }
+
+                if ($ticket['FacilityID']) {
+                    $temp = get_related_tickets_by_facility($ticket['FacilityID'], $ticket_id);
+                    foreach ($temp as $row) {
+                        if (!isset($seen_ids[$row['TicketID']])) {
+                            $related_facility[] = $row;
+                            $seen_ids[$row['TicketID']] = true;
+                        }
+                    }
+                }
+
+                if ($ticket['LocationID']) {
+                    $temp = get_related_tickets_by_location($ticket['LocationID'], $ticket_id, $ticket['FacilityID'] ?? null);
+                    foreach ($temp as $row) {
+                        if (!isset($seen_ids[$row['TicketID']])) {
+                            $related_location[] = $row;
+                            $seen_ids[$row['TicketID']] = true;
+                        }
+                    }
+                }
+
+                $facility_info = null;
+                $location_info = null;
+                if ($ticket['FacilityID']) {
+                    $facility_info = get_facility_info($ticket['FacilityID']);
+                }
+                if ($ticket['LocationID']) {
+                    $location_info = get_location_info($ticket['LocationID']);
+                }
+                $statuses = get_all_statuses();
+                $priorities = get_all_priorities();
+                $agents = load_agents();
+                $allowed_extension_strings = get_allowed_extension_strings();
+                $allowed_accept = $allowed_extension_strings['accept'];
+                $allowed_hint = $allowed_extension_strings['hint'];
+                $form_update_text = $update_text_raw;
+                $form_is_solution = true;
+
+                include 'templates/ticket_view.php';
+                exit;
+            }
 
             if ($ticket['StatusName'] == 'Neu' && !$status_id && ($update_text !== '' || $priority_id !== '' || $assign_agent !== '' || !empty($_FILES['attachment']['name']))) {
                 $in_progress = query_db("SELECT StatusID FROM TicketStatus WHERE StatusName = 'In Arbeit'", [], true);
@@ -329,6 +389,8 @@ if ($action === 'view_ticket') {
     $allowed_extension_strings = get_allowed_extension_strings();
     $allowed_accept = $allowed_extension_strings['accept'];
     $allowed_hint = $allowed_extension_strings['hint'];
+    $form_update_text = $form_update_text ?? '';
+    $form_is_solution = $form_is_solution ?? false;
     include 'templates/ticket_view.php';
     exit;
 }

--- a/php/templates/ticket_view.php
+++ b/php/templates/ticket_view.php
@@ -231,11 +231,11 @@
                     </div>
                     <div class="form-group">
                         <label for="update_text">Kommentar:</label>
-                        <textarea id="update_text" name="update_text" rows="4"></textarea>
+                        <textarea id="update_text" name="update_text" rows="4"><?php echo htmlspecialchars($form_update_text ?? ''); ?></textarea>
                     </div>
                     <div class="form-group checkbox-group">
-                        <input type="checkbox" id="is_solution" name="is_solution">
-                        <label for="is_solution">Als Lösung markieren. Lösung ist Lösung! Das Ticket kann danach nicht mehr bearbeitet werden.</label>                    
+                        <input type="checkbox" id="is_solution" name="is_solution" <?php if (!empty($form_is_solution)) echo 'checked'; ?>>
+                        <label for="is_solution">Als Lösung markieren. Lösung ist Lösung! Das Ticket kann danach nicht mehr bearbeitet werden.</label>
                     </div>
                     <div class="form-group">
                         <label for="attachment">Anhang hinzufügen:</label>
@@ -260,6 +260,8 @@
 document.addEventListener('DOMContentLoaded', function() {
     const isSolution = document.getElementById('is_solution');
     const statusSelect = document.getElementById('status_id');
+    const updateForm = document.querySelector('.update-form form');
+    const updateText = document.getElementById('update_text');
     if (!isSolution || !statusSelect) {
         return;
     }
@@ -326,6 +328,16 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         }
     });
+
+    if (updateForm && updateText) {
+        updateForm.addEventListener('submit', function(event) {
+            if (isSolution.checked && updateText.value.trim() === '') {
+                event.preventDefault();
+                alert('Bitte gib einen Kommentar ein, bevor du eine Lösung speicherst.');
+                updateText.focus();
+            }
+        });
+    }
 });
 </script>
 <?php include 'templates/footer.php'; ?>

--- a/php/tests/manual_solution_validation.md
+++ b/php/tests/manual_solution_validation.md
@@ -1,0 +1,10 @@
+# QA: Lösungseintrag ohne Kommentar verhindern
+
+1. Melde dich im System an und öffne ein bestehendes Ticket, das noch nicht als gelöst markiert ist.
+2. Scrolle zum Formular "Aktualisieren" und aktiviere die Checkbox **Als Lösung markieren**.
+3. Lass das Kommentarfeld leer und klicke auf **Aktualisieren**.
+   - Erwartet: Der Submit wird client-seitig mit einem Hinweis unterbunden.
+4. Trage anschließend einen Kommentar mit beliebigem Text ein, lass die Checkbox aktiviert und sende das Formular erneut ab.
+   - Erwartet: Der Server akzeptiert die Eingabe und speichert die Lösung.
+5. Wiederhole Schritt 2 und 3, indem du JavaScript deaktivierst (z. B. über die Browser-Entwicklertools) oder die Anfrage direkt per Netzwerk-Tool sendest.
+   - Erwartet: Der Server bricht mit der Fehlermeldung *„Bitte gib einen Kommentar ein, bevor du eine Lösung speicherst.“* ab und zeigt das Formular mit dem zuvor eingegebenen Text erneut an.


### PR DESCRIPTION
## Summary
- add server-side validation to block empty solution submissions and re-render the ticket view with the entered text
- keep the solution checkbox/textarea state on validation errors and add a client-side guard before submitting
- document a manual QA flow that covers both client- and server-side checks

## Testing
- php -l php/index.php
- php -l php/templates/ticket_view.php

------
https://chatgpt.com/codex/tasks/task_e_68d69000e3f48327be3fce12b0c55ddf